### PR TITLE
Feat/UNI2-7-member-activity-availability-states

### DIFF
--- a/apps/backend/src/members/dto/create-member.dto.ts
+++ b/apps/backend/src/members/dto/create-member.dto.ts
@@ -14,7 +14,8 @@ import {
   ValidatorConstraintInterface,
 } from 'class-validator';
 import { AreaRole } from '../../common/enums/area-role.enum';
-import { MemberStatus } from '../member.entity';
+import { MemberActivityStatus } from '../enums/member-activity-status.enum';
+import { MemberAvailabilityStatus } from '../enums/member-availability-status.enum';
 
 const trimString = ({ value }: { value: unknown }) =>
   typeof value === 'string' ? value.trim() : value;
@@ -113,7 +114,15 @@ export class CreateMemberDto {
   @Length(1, 80, { each: true })
   skills: string[];
 
-  @IsEnum(MemberStatus)
+  @IsEnum(MemberActivityStatus)
   @IsOptional()
-  status?: MemberStatus;
+  activityStatus?: MemberActivityStatus;
+
+  @IsEnum(MemberAvailabilityStatus)
+  @IsOptional()
+  availabilityStatus?: MemberAvailabilityStatus;
+
+  @IsEnum(MemberAvailabilityStatus)
+  @IsOptional()
+  status?: MemberAvailabilityStatus;
 }

--- a/apps/backend/src/members/dto/get-members-filter.dto.ts
+++ b/apps/backend/src/members/dto/get-members-filter.dto.ts
@@ -8,21 +8,48 @@ import {
   IsString,
   Length,
 } from 'class-validator';
-import { MemberStatus } from '../member.entity';
+import { MemberActivityStatus } from '../enums/member-activity-status.enum';
+import { MemberAvailabilityStatus } from '../enums/member-availability-status.enum';
 
 export class GetMembersFilterDto {
   @IsOptional()
   @Transform(({ value }) => {
     if (typeof value === 'string') {
-      const match = Object.values(MemberStatus).find(
-        (status) => status.toLowerCase() === value.toLowerCase()
+      const match = Object.values(MemberAvailabilityStatus).find(
+        (status) => status.toLowerCase() === value.toLowerCase(),
       );
       return match || value;
     }
     return value;
   })
-  @IsEnum(MemberStatus)
-  status?: MemberStatus;
+  @IsEnum(MemberAvailabilityStatus)
+  status?: MemberAvailabilityStatus;
+
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      const match = Object.values(MemberActivityStatus).find(
+        (status) => status.toLowerCase() === value.toLowerCase(),
+      );
+      return match || value;
+    }
+    return value;
+  })
+  @IsEnum(MemberActivityStatus)
+  activityStatus?: MemberActivityStatus;
+
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      const match = Object.values(MemberAvailabilityStatus).find(
+        (status) => status.toLowerCase() === value.toLowerCase(),
+      );
+      return match || value;
+    }
+    return value;
+  })
+  @IsEnum(MemberAvailabilityStatus)
+  availabilityStatus?: MemberAvailabilityStatus;
 
   @IsOptional()
   @Transform(({ value }) => {

--- a/apps/backend/src/members/dto/get-members-filter.dto.ts
+++ b/apps/backend/src/members/dto/get-members-filter.dto.ts
@@ -11,73 +11,81 @@ import {
 import { MemberActivityStatus } from '../enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from '../enums/member-availability-status.enum';
 
+const normalizeEnumValue = <T extends string>(
+  value: unknown,
+  values: readonly T[],
+): unknown => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  return (
+    values.find((status) => status.toLowerCase() === value.toLowerCase()) ??
+    value
+  );
+};
+
+const normalizeNumber = (value: unknown): unknown => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const parsed = Number(value);
+  return Number.isNaN(parsed) || value.trim() === '' ? value : parsed;
+};
+
+const normalizeSkills = (value: unknown): unknown => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const items: readonly unknown[] =
+    typeof value === 'string' ? [value] : Array.isArray(value) ? value : [];
+
+  if (
+    items.length === 0 &&
+    !Array.isArray(value) &&
+    typeof value !== 'string'
+  ) {
+    return value;
+  }
+
+  return items.map((item) =>
+    typeof item === 'string'
+      ? item.trim().replace(/\s+/g, ' ').toLowerCase()
+      : item,
+  );
+};
+
 export class GetMembersFilterDto {
   @IsOptional()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      const match = Object.values(MemberAvailabilityStatus).find(
-        (status) => status.toLowerCase() === value.toLowerCase(),
-      );
-      return match || value;
-    }
-    return value;
-  })
+  @Transform(({ value }: { value: unknown }) =>
+    normalizeEnumValue(value, Object.values(MemberAvailabilityStatus)),
+  )
   @IsEnum(MemberAvailabilityStatus)
   status?: MemberAvailabilityStatus;
 
   @IsOptional()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      const match = Object.values(MemberActivityStatus).find(
-        (status) => status.toLowerCase() === value.toLowerCase(),
-      );
-      return match || value;
-    }
-    return value;
-  })
+  @Transform(({ value }: { value: unknown }) =>
+    normalizeEnumValue(value, Object.values(MemberActivityStatus)),
+  )
   @IsEnum(MemberActivityStatus)
   activityStatus?: MemberActivityStatus;
 
   @IsOptional()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      const match = Object.values(MemberAvailabilityStatus).find(
-        (status) => status.toLowerCase() === value.toLowerCase(),
-      );
-      return match || value;
-    }
-    return value;
-  })
+  @Transform(({ value }: { value: unknown }) =>
+    normalizeEnumValue(value, Object.values(MemberAvailabilityStatus)),
+  )
   @IsEnum(MemberAvailabilityStatus)
   availabilityStatus?: MemberAvailabilityStatus;
 
   @IsOptional()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      const parsed = Number(value);
-      return isNaN(parsed) || value.trim() === '' ? value : parsed;
-    }
-    return value;
-  })
+  @Transform(({ value }: { value: unknown }) => normalizeNumber(value))
   @IsNumber()
   areaId?: number;
 
   @IsOptional()
-  @Transform(({ value }) => {
-    if (value === undefined) return value;
-
-    let arr: any[] = [];
-    if (typeof value === 'string') arr = [value];
-    else if (Array.isArray(value)) arr = value;
-    else return value;
-
-    return arr.map((item) => {
-      if (typeof item === 'string') {
-        return item.trim().replace(/\s+/g, ' ').toLowerCase();
-      }
-      return item;
-    });
-  })
+  @Transform(({ value }: { value: unknown }) => normalizeSkills(value))
   @IsArray()
   @ArrayMinSize(1)
   @IsString({ each: true })

--- a/apps/backend/src/members/dto/update-member.dto.ts
+++ b/apps/backend/src/members/dto/update-member.dto.ts
@@ -1,10 +1,19 @@
 import { IsEnum, IsInt, IsOptional } from 'class-validator';
-import { MemberStatus } from '../member.entity';
+import { MemberActivityStatus } from '../enums/member-activity-status.enum';
+import { MemberAvailabilityStatus } from '../enums/member-availability-status.enum';
 
 export class UpdateMemberDto {
-  @IsEnum(MemberStatus)
+  @IsEnum(MemberActivityStatus)
   @IsOptional()
-  status?: MemberStatus;
+  activityStatus?: MemberActivityStatus;
+
+  @IsEnum(MemberAvailabilityStatus)
+  @IsOptional()
+  availabilityStatus?: MemberAvailabilityStatus;
+
+  @IsEnum(MemberAvailabilityStatus)
+  @IsOptional()
+  status?: MemberAvailabilityStatus;
 
   @IsInt()
   @IsOptional()

--- a/apps/backend/src/members/enums/member-activity-status.enum.ts
+++ b/apps/backend/src/members/enums/member-activity-status.enum.ts
@@ -1,0 +1,7 @@
+export enum MemberActivityStatus {
+  /** Miembro participa activamente en la organización. */
+  ACTIVE = 'active',
+
+  /** Miembro ya no participa. Su historial y datos se conservan. */
+  INACTIVE = 'inactive',
+}

--- a/apps/backend/src/members/enums/member-availability-status.enum.ts
+++ b/apps/backend/src/members/enums/member-availability-status.enum.ts
@@ -1,0 +1,13 @@
+export enum MemberAvailabilityStatus {
+  /** Disponible: puede ser asignado a equipos. */
+  AVAILABLE = 'available',
+
+  /** No disponible: no puede ser asignado temporalmente. */
+  UNAVAILABLE = 'unavailable',
+
+  // TODO(auth): cuando exista un módulo de autenticación, usar este valor
+  // para bloquear el acceso al sistema del miembro mientras se preservan
+  // sus datos e historial.
+  /** Inhabilitado: acceso al sistema bloqueado; datos e historial intactos. */
+  DISABLED = 'disabled',
+}

--- a/apps/backend/src/members/member.entity.ts
+++ b/apps/backend/src/members/member.entity.ts
@@ -13,12 +13,8 @@ import {
 import { Area } from '../area/entities/area.entity';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { Skill } from '../skills/skill.entity';
-
-export enum MemberStatus {
-  Available = 'Available',
-  Unavailable = 'Unavailable',
-  Disabled = 'Disabled',
-}
+import { MemberActivityStatus } from './enums/member-activity-status.enum';
+import { MemberAvailabilityStatus } from './enums/member-availability-status.enum';
 
 @Entity({ name: 'members' })
 @Unique(['institution', 'studentCode'])
@@ -58,6 +54,22 @@ export class Member {
   @JoinColumn({ name: 'area_id' })
   area: Area | null;
 
+  @Column({
+    name: 'activity_status',
+    type: 'enum',
+    enum: MemberActivityStatus,
+    default: MemberActivityStatus.ACTIVE,
+  })
+  activityStatus: MemberActivityStatus;
+
+  @Column({
+    name: 'availability_status',
+    type: 'enum',
+    enum: MemberAvailabilityStatus,
+    default: MemberAvailabilityStatus.AVAILABLE,
+  })
+  availabilityStatus: MemberAvailabilityStatus;
+
   @ManyToMany(() => Skill, (skill) => skill.members)
   @JoinTable()
   skills: Skill[];
@@ -67,7 +79,4 @@ export class Member {
 
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
-
-  @Column({ type: 'varchar', length: 20, default: MemberStatus.Available })
-  status: MemberStatus;
 }

--- a/apps/backend/src/members/members.controller.spec.ts
+++ b/apps/backend/src/members/members.controller.spec.ts
@@ -3,7 +3,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ROLES_KEY } from '../common/decorators/roles.decorator';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { RolesGuard } from '../common/guards/roles.guard';
-import { Member, MemberStatus } from './member.entity';
+import { MemberActivityStatus } from './enums/member-activity-status.enum';
+import { MemberAvailabilityStatus } from './enums/member-availability-status.enum';
+import { Member } from './member.entity';
 import { MembersController } from './members.controller';
 import { MembersService } from './members.service';
 
@@ -57,10 +59,11 @@ describe('MembersController', () => {
       role: AreaRole.MIEMBRO,
       areaId: null,
       area: null,
+      activityStatus: MemberActivityStatus.ACTIVE,
+      availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
       skills: [],
       createdAt: new Date(),
       updatedAt: new Date(),
-      status: MemberStatus.Available,
     } satisfies Member;
 
     const createMemberDto = {
@@ -88,7 +91,7 @@ describe('MembersController', () => {
       areaId: '2',
     };
     const storedMembers: Member[] = [];
-    const filterDto = { status: MemberStatus.Available };
+    const filterDto = { status: MemberAvailabilityStatus.AVAILABLE };
 
     mockMembersService.findAccessible.mockResolvedValue(storedMembers);
 

--- a/apps/backend/src/members/members.module.ts
+++ b/apps/backend/src/members/members.module.ts
@@ -8,7 +8,10 @@ import { MembersController } from './members.controller';
 import { MembersService } from './members.service';
 
 @Module({
-  imports: [AccessControlModule, TypeOrmModule.forFeature([Member, Skill, Area])],
+  imports: [
+    AccessControlModule,
+    TypeOrmModule.forFeature([Member, Skill, Area]),
+  ],
   controllers: [MembersController],
   providers: [MembersService],
 })

--- a/apps/backend/src/members/members.service.spec.ts
+++ b/apps/backend/src/members/members.service.spec.ts
@@ -1,7 +1,4 @@
-import {
-  ForbiddenException,
-  NotFoundException,
-} from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { QueryFailedError, Repository } from 'typeorm';
@@ -9,7 +6,9 @@ import { Area } from '../area/entities/area.entity';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { Skill } from '../skills/skill.entity';
 import { CreateMemberDto } from './dto/create-member.dto';
-import { Member, MemberStatus } from './member.entity';
+import { MemberActivityStatus } from './enums/member-activity-status.enum';
+import { MemberAvailabilityStatus } from './enums/member-availability-status.enum';
+import { Member } from './member.entity';
 import { MembersService } from './members.service';
 
 type MemberRepositoryMock = Partial<
@@ -118,10 +117,11 @@ describe('MembersService', () => {
       role: areaDirectiveMemberDto.role,
       areaId: areaDirectiveMemberDto.areaId ?? null,
       area: null,
+      activityStatus: MemberActivityStatus.ACTIVE,
+      availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
       skills: persistedSkills,
       createdAt: new Date(),
       updatedAt: new Date(),
-      status: MemberStatus.Available,
     };
   });
 
@@ -184,10 +184,11 @@ describe('MembersService', () => {
       role: AreaRole.MIEMBRO,
       areaId: null,
       area: null,
+      activityStatus: MemberActivityStatus.ACTIVE,
+      availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
       skills: externalSkills,
       createdAt: new Date(),
       updatedAt: new Date(),
-      status: MemberStatus.Available,
     };
 
     skillsRepository.find?.mockResolvedValue(externalSkills);
@@ -241,10 +242,11 @@ describe('MembersService', () => {
         role: AreaRole.MIEMBRO,
         areaId: 3,
         area: null,
+        activityStatus: MemberActivityStatus.ACTIVE,
+        availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
         skills: [createSkill(4, 'gestion')],
         createdAt: new Date(),
         updatedAt: new Date(),
-        status: MemberStatus.Available,
       },
     ];
     const queryBuilderMock = createQueryBuilderMock(storedMembers);
@@ -271,11 +273,13 @@ describe('MembersService', () => {
   });
 
   describe('update', () => {
-    it('successfully updates a member status', async () => {
-      const updateDto = { status: MemberStatus.Unavailable };
+    it('successfully updates a member availability status', async () => {
+      const updateDto = {
+        availabilityStatus: MemberAvailabilityStatus.UNAVAILABLE,
+      };
       const updatedMember = {
         ...persistedAreaDirectiveMember,
-        status: MemberStatus.Unavailable,
+        availabilityStatus: MemberAvailabilityStatus.UNAVAILABLE,
       };
 
       membersRepository.preload?.mockResolvedValue(updatedMember);
@@ -286,9 +290,47 @@ describe('MembersService', () => {
       );
       expect(membersRepository.preload).toHaveBeenCalledWith({
         id: 10,
-        status: MemberStatus.Unavailable,
+        availabilityStatus: MemberAvailabilityStatus.UNAVAILABLE,
       });
       expect(membersRepository.save).toHaveBeenCalledWith(updatedMember);
+    });
+
+    it('supports legacy status update input as availability status', async () => {
+      const updateDto = { status: MemberAvailabilityStatus.UNAVAILABLE };
+      const updatedMember = {
+        ...persistedAreaDirectiveMember,
+        availabilityStatus: MemberAvailabilityStatus.UNAVAILABLE,
+      };
+
+      membersRepository.preload?.mockResolvedValue(updatedMember);
+      membersRepository.save?.mockResolvedValue(updatedMember);
+
+      await expect(service.update(10, updateDto)).resolves.toEqual(
+        updatedMember,
+      );
+      expect(membersRepository.preload).toHaveBeenCalledWith({
+        id: 10,
+        availabilityStatus: MemberAvailabilityStatus.UNAVAILABLE,
+      });
+    });
+
+    it('successfully updates a member activity status', async () => {
+      const updateDto = { activityStatus: MemberActivityStatus.INACTIVE };
+      const updatedMember = {
+        ...persistedAreaDirectiveMember,
+        activityStatus: MemberActivityStatus.INACTIVE,
+      };
+
+      membersRepository.preload?.mockResolvedValue(updatedMember);
+      membersRepository.save?.mockResolvedValue(updatedMember);
+
+      await expect(service.update(10, updateDto)).resolves.toEqual(
+        updatedMember,
+      );
+      expect(membersRepository.preload).toHaveBeenCalledWith({
+        id: 10,
+        activityStatus: MemberActivityStatus.INACTIVE,
+      });
     });
 
     it('throws NotFoundException when updating with a non-existent areaId', async () => {
@@ -306,7 +348,9 @@ describe('MembersService', () => {
     });
 
     it('throws NotFoundException when member to update does not exist', async () => {
-      const updateDto = { status: MemberStatus.Disabled };
+      const updateDto = {
+        availabilityStatus: MemberAvailabilityStatus.DISABLED,
+      };
 
       membersRepository.preload?.mockResolvedValue(null);
 
@@ -315,7 +359,7 @@ describe('MembersService', () => {
       );
       expect(membersRepository.preload).toHaveBeenCalledWith({
         id: 99,
-        status: MemberStatus.Disabled,
+        availabilityStatus: MemberAvailabilityStatus.DISABLED,
       });
       expect(membersRepository.save).not.toHaveBeenCalled();
     });
@@ -376,12 +420,12 @@ describe('MembersService', () => {
           role: AreaRole.DIRECTIVA_DE_AREA,
           areaId: '3',
         },
-        { areaId: 99, status: MemberStatus.Available },
+        { areaId: 99, status: MemberAvailabilityStatus.AVAILABLE },
       ),
     ).resolves.toEqual(scopedMembers);
     expect(queryBuilderMock.andWhere).toHaveBeenCalledWith(
-      'member.status = :status',
-      { status: MemberStatus.Available },
+      'member.availabilityStatus = :availabilityStatus',
+      { availabilityStatus: MemberAvailabilityStatus.AVAILABLE },
     );
     expect(queryBuilderMock.andWhere).toHaveBeenCalledWith(
       'area.id = :areaId',

--- a/apps/backend/src/members/members.service.spec.ts
+++ b/apps/backend/src/members/members.service.spec.ts
@@ -1,7 +1,7 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { QueryFailedError, Repository } from 'typeorm';
+import { In, QueryFailedError, Repository } from 'typeorm';
 import { Area } from '../area/entities/area.entity';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { Skill } from '../skills/skill.entity';
@@ -139,14 +139,19 @@ describe('MembersService', () => {
     });
     expect(skillsRepository.find).toHaveBeenCalledWith({
       where: {
-        name: expect.anything(),
+        name: In(['typescript', 'testing']),
       },
     });
-    const { skills, areaId, ...restDto } = areaDirectiveMemberDto;
     expect(membersRepository.create).toHaveBeenCalledWith({
-      ...restDto,
+      institution: areaDirectiveMemberDto.institution,
+      studentCode: areaDirectiveMemberDto.studentCode,
+      firstNames: areaDirectiveMemberDto.firstNames,
+      lastNames: areaDirectiveMemberDto.lastNames,
+      major: areaDirectiveMemberDto.major,
+      birthDate: areaDirectiveMemberDto.birthDate,
+      role: areaDirectiveMemberDto.role,
       skills: persistedSkills,
-      area: { id: areaId },
+      area: { id: areaDirectiveMemberDto.areaId },
     });
     expect(membersRepository.save).toHaveBeenCalledWith(
       persistedAreaDirectiveMember,
@@ -198,9 +203,13 @@ describe('MembersService', () => {
     await expect(service.create(externalMemberDto)).resolves.toEqual(
       persistedMember,
     );
-    const { skills, areaId, ...restDto } = externalMemberDto;
     expect(membersRepository.create).toHaveBeenCalledWith({
-      ...restDto,
+      institution: externalMemberDto.institution,
+      firstNames: externalMemberDto.firstNames,
+      lastNames: externalMemberDto.lastNames,
+      major: externalMemberDto.major,
+      birthDate: externalMemberDto.birthDate,
+      role: externalMemberDto.role,
       skills: externalSkills,
       area: undefined,
     });

--- a/apps/backend/src/members/members.service.ts
+++ b/apps/backend/src/members/members.service.ts
@@ -32,7 +32,7 @@ export class MembersService {
   ) {}
 
   async create(createMemberDto: CreateMemberDto): Promise<Member> {
-    const { skills, areaId, ...restDto } = createMemberDto;
+    const { skills, areaId, status, ...restDto } = createMemberDto;
 
     if (areaId !== undefined && areaId !== null) {
       await this.validateAreaExists(areaId);
@@ -42,6 +42,10 @@ export class MembersService {
 
     const member = this.membersRepository.create({
       ...restDto,
+      ...(status !== undefined &&
+        restDto.availabilityStatus === undefined && {
+          availabilityStatus: status,
+        }),
       role: restDto.role ?? AreaRole.MIEMBRO,
       skills: resolvedSkills,
       area:
@@ -72,7 +76,9 @@ export class MembersService {
   }
 
   async update(id: number, updateMemberDto: UpdateMemberDto): Promise<Member> {
-    const { status, areaId } = updateMemberDto;
+    const { activityStatus, availabilityStatus, status, areaId } =
+      updateMemberDto;
+    const resolvedAvailabilityStatus = availabilityStatus ?? status;
 
     if (areaId !== undefined && areaId !== null) {
       await this.validateAreaExists(areaId);
@@ -80,7 +86,10 @@ export class MembersService {
 
     const preloadData: DeepPartial<Member> = {
       id,
-      ...(status !== undefined && { status }),
+      ...(activityStatus !== undefined && { activityStatus }),
+      ...(resolvedAvailabilityStatus !== undefined && {
+        availabilityStatus: resolvedAvailabilityStatus,
+      }),
       ...(areaId !== undefined && {
         area: areaId === null ? null : { id: areaId },
       }),
@@ -96,7 +105,9 @@ export class MembersService {
   }
 
   findAll(filterDto?: GetMembersFilterDto): Promise<Member[]> {
-    const status = filterDto?.status;
+    const activityStatus = filterDto?.activityStatus;
+    const availabilityStatus =
+      filterDto?.availabilityStatus ?? filterDto?.status;
     const areaId = filterDto?.areaId;
     const skills = filterDto?.skills;
 
@@ -108,8 +119,16 @@ export class MembersService {
       .addOrderBy('member.firstNames', 'ASC')
       .addOrderBy('member.createdAt', 'ASC');
 
-    if (status) {
-      query.andWhere('member.status = :status', { status });
+    if (activityStatus) {
+      query.andWhere('member.activityStatus = :activityStatus', {
+        activityStatus,
+      });
+    }
+
+    if (availabilityStatus) {
+      query.andWhere('member.availabilityStatus = :availabilityStatus', {
+        availabilityStatus,
+      });
     }
 
     if (areaId !== undefined) {


### PR DESCRIPTION
## Summary
This PR adds separate member states for activity and availability.
The goal is to distinguish whether a member is still active in the organization and whether they can currently be assigned to teams or tasks.

## Related Issue / Requirement
- Issue: UNI2-7
- Requirement: member activity and availability state management

## What Changed
- Added `MemberActivityStatus` and `MemberAvailabilityStatus` enums.
- Updated the `Member` entity to store `activityStatus` and `availabilityStatus`.
- Updated create, update, and filter DTOs to accept the new states.
- Updated `MembersService` to create, update, and filter members by state.
- Kept `status` as a temporary compatibility alias for availability.
- Added unit tests for member state creation, updates, and filtering.

## How to Test
- Run `npm run test -w backend -- --runInBand`.
- Run `npm run build -w backend`.
- Verify that `PATCH /members/:id` can update `activityStatus`.
- Verify that `PATCH /members/:id` can update `availabilityStatus`.
- Verify that `GET /members` can filter by `activityStatus` and `availabilityStatus`.

## Screenshots / Evidence
<img width="802" height="421" alt="image" src="https://github.com/user-attachments/assets/f01818a8-3407-4c1c-8a51-c945f5c53d94" />

## Notes
`status` is still accepted for now because the current main branch already used it for availability-related updates and filters. New code should use `availabilityStatus` directly.