### PR TITLE
Uni2 12 featmembers restrict internal member fields by area role

### DIFF
--- a/apps/backend/src/members/dto/member-response.dto.ts
+++ b/apps/backend/src/members/dto/member-response.dto.ts
@@ -1,0 +1,6 @@
+import { Member } from '../member.entity';
+
+type InternalMemberField = 'activityStatus' | 'availabilityStatus';
+
+export type MemberResponse = Omit<Member, InternalMemberField> &
+  Partial<Pick<Member, InternalMemberField>>;

--- a/apps/backend/src/members/members.controller.ts
+++ b/apps/backend/src/members/members.controller.ts
@@ -16,6 +16,7 @@ import { RolesGuard } from '../common/guards/roles.guard';
 import type { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { CreateMemberDto } from './dto/create-member.dto';
 import { GetMembersFilterDto } from './dto/get-members-filter.dto';
+import { MemberResponse } from './dto/member-response.dto';
 import { UpdateMemberDto } from './dto/update-member.dto';
 import { Member } from './member.entity';
 import { MembersService } from './members.service';
@@ -36,7 +37,7 @@ export class MembersController {
   findAll(
     @CurrentAccessActor() accessActor: RequestAccessActor,
     @Query() filterDto: GetMembersFilterDto,
-  ): Promise<Member[]> {
+  ): Promise<MemberResponse[]> {
     return this.membersService.findAccessible(accessActor, filterDto);
   }
 

--- a/apps/backend/src/members/members.service.ts
+++ b/apps/backend/src/members/members.service.ts
@@ -13,8 +13,10 @@ import { parseAreaId } from '../common/utils/parse-area-id.util';
 import { Skill } from '../skills/skill.entity';
 import { CreateMemberDto } from './dto/create-member.dto';
 import { GetMembersFilterDto } from './dto/get-members-filter.dto';
+import { MemberResponse } from './dto/member-response.dto';
 import { UpdateMemberDto } from './dto/update-member.dto';
 import { Member } from './member.entity';
+import { toMemberResponse } from './utils/member-response.util';
 
 type DatabaseErrorWithCode = {
   code: string;
@@ -156,23 +158,34 @@ export class MembersService {
   async findAccessible(
     accessActor: RequestAccessActor,
     filterDto?: GetMembersFilterDto,
-  ): Promise<Member[]> {
+  ): Promise<MemberResponse[]> {
     if (accessActor.role === AreaRole.PRESIDENCIA) {
-      return this.findAll(filterDto);
+      const members = await this.findAll(filterDto);
+
+      return this.toAccessibleMemberResponses(members, accessActor);
     }
 
     if (accessActor.role === AreaRole.DIRECTIVA_DE_AREA) {
       const areaId = parseAreaId(accessActor.areaId);
 
-      return this.findAll({
+      const members = await this.findAll({
         ...filterDto,
         areaId,
       });
+
+      return this.toAccessibleMemberResponses(members, accessActor);
     }
 
     throw new ForbiddenException(
       'Project-scoped member access is not available on this endpoint yet',
     );
+  }
+
+  private toAccessibleMemberResponses(
+    members: Member[],
+    accessActor: RequestAccessActor,
+  ): MemberResponse[] {
+    return members.map((member) => toMemberResponse(member, accessActor.role));
   }
 
   private async resolveSkills(skillNames: string[]): Promise<Skill[]> {

--- a/apps/backend/src/members/utils/member-response.util.spec.ts
+++ b/apps/backend/src/members/utils/member-response.util.spec.ts
@@ -1,0 +1,45 @@
+import { AreaRole } from '../../common/enums/area-role.enum';
+import { MemberActivityStatus } from '../enums/member-activity-status.enum';
+import { MemberAvailabilityStatus } from '../enums/member-availability-status.enum';
+import { Member } from '../member.entity';
+import { toMemberResponse } from './member-response.util';
+
+const member: Member = {
+  id: 1,
+  institution: 'UNI',
+  studentCode: '20230001',
+  firstNames: 'Ana Lucia',
+  lastNames: 'Rojas Perez',
+  major: 'Ingenieria de Sistemas',
+  birthDate: '2004-04-18',
+  role: AreaRole.MIEMBRO,
+  areaId: 3,
+  area: null,
+  activityStatus: MemberActivityStatus.ACTIVE,
+  availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
+  skills: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('toMemberResponse', () => {
+  it.each([AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA])(
+    'keeps internal member fields for %s',
+    (role) => {
+      expect(toMemberResponse(member, role)).toEqual(member);
+    },
+  );
+
+  it('removes internal member fields for regular members', () => {
+    const response = toMemberResponse(member, AreaRole.MIEMBRO);
+
+    expect(response).not.toHaveProperty('activityStatus');
+    expect(response).not.toHaveProperty('availabilityStatus');
+    expect(response).toMatchObject({
+      id: member.id,
+      firstNames: member.firstNames,
+      lastNames: member.lastNames,
+      skills: member.skills,
+    });
+  });
+});

--- a/apps/backend/src/members/utils/member-response.util.ts
+++ b/apps/backend/src/members/utils/member-response.util.ts
@@ -1,0 +1,28 @@
+import { AreaRole } from '../../common/enums/area-role.enum';
+import { MemberResponse } from '../dto/member-response.dto';
+import { Member } from '../member.entity';
+
+const INTERNAL_MEMBER_FIELDS = [
+  'activityStatus',
+  'availabilityStatus',
+] as const;
+
+export const canViewInternalMemberFields = (role: AreaRole): boolean =>
+  role === AreaRole.PRESIDENCIA || role === AreaRole.DIRECTIVA_DE_AREA;
+
+export const toMemberResponse = (
+  member: Member,
+  role: AreaRole,
+): MemberResponse => {
+  if (canViewInternalMemberFields(role)) {
+    return member;
+  }
+
+  const response: MemberResponse = { ...member };
+
+  for (const field of INTERNAL_MEMBER_FIELDS) {
+    delete response[field];
+  }
+
+  return response;
+};


### PR DESCRIPTION
## Summary
This PR restricts the visibility of internal member fields based on the requester role.
The goal is to ensure that only Presidency and Area Leadership can see internal fields such as activity and availability status in member responses.

## Related Issue / Requirement
- Issue: UNI2-12
- GitHub issue: #8

## What Changed
- Added `MemberResponse` para representar respuestas de miembros con campos internos opcionales.
- Added utilidad `toMemberResponse` para ocultar campos internos según el rol.
- Updated `MembersService` para aplicar el filtrado de respuesta en el listado de miembros.
- Updated `MembersController` para usar el flujo de acceso con `RequestAccessActor`.
- Added pruebas para validar que Presidencia y Directiva de Área reciben campos internos.
- Added pruebas para validar que miembros regulares no reciben campos internos.
- Fixed conflictos del merge con `main`.

## How to Test
- Run backend type-check:
  `npm run type-check -w backend`
- Run the related member module tests:
  `npm test -w backend -- members.service.spec.ts members.controller.spec.ts member-response.util.spec.ts`
- Verify that responses for Presidency and Area Leadership include `activityStatus` and `availabilityStatus`.
- Verify that responses for regular members do not include `activityStatus` or `availabilityStatus`.

## Screenshots / Evidence
Test results:
- `npm run type-check -w backend` passed successfully.
<img width="708" height="92" alt="image" src="https://github.com/user-attachments/assets/562885e2-6b36-43fa-9d14-f02995f8fd9a" />

- `npm test -w backend -- members.service.spec.ts members.controller.spec.ts member-response.util.spec.ts` passed successfully.
<img width="1101" height="408" alt="image" src="https://github.com/user-attachments/assets/6813b9c1-dd96-4bd1-a7e1-36f888f005aa" />