### PR TITLE
Uni2 20 featproject define and manage project phase structure

### DIFF
--- a/apps/backend/src/projects/constants/default-project-phases.constant.ts
+++ b/apps/backend/src/projects/constants/default-project-phases.constant.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_PROJECT_PHASES = [
+  'Planning',
+  'Execution',
+  'Review',
+  'Launch',
+] as const;

--- a/apps/backend/src/projects/dto/create-project-phase.dto.ts
+++ b/apps/backend/src/projects/dto/create-project-phase.dto.ts
@@ -1,0 +1,19 @@
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+const trimString = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+export class CreateProjectPhaseDto {
+  @Transform(trimString)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  name: string;
+
+  @Transform(trimString)
+  @IsString()
+  @IsOptional()
+  @MaxLength(2000)
+  description?: string;
+}

--- a/apps/backend/src/projects/dto/reorder-project-phases.dto.ts
+++ b/apps/backend/src/projects/dto/reorder-project-phases.dto.ts
@@ -1,0 +1,18 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsInt,
+  Min,
+} from 'class-validator';
+
+export class ReorderProjectPhasesDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @Type(() => Number)
+  @IsInt({ each: true })
+  @Min(1, { each: true })
+  phaseIds: number[];
+}

--- a/apps/backend/src/projects/dto/update-project-phase.dto.ts
+++ b/apps/backend/src/projects/dto/update-project-phase.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateProjectPhaseDto } from './create-project-phase.dto';
+
+export class UpdateProjectPhaseDto extends PartialType(CreateProjectPhaseDto) {}

--- a/apps/backend/src/projects/entities/project-phase.entity.ts
+++ b/apps/backend/src/projects/entities/project-phase.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+
+@Entity('project_phases')
+export class ProjectPhase {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 2000, nullable: true })
+  description: string | null;
+
+  @Column({ name: 'order_index', type: 'int' })
+  orderIndex: number;
+
+  @Column({ name: 'project_id', type: 'int' })
+  projectId: number;
+
+  @ManyToOne(() => Project, (project) => project.phases, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'project_id' })
+  project: Project;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/apps/backend/src/projects/entities/project.entity.ts
+++ b/apps/backend/src/projects/entities/project.entity.ts
@@ -4,10 +4,12 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { Area } from '../../area/entities/area.entity';
+import { ProjectPhase } from './project-phase.entity';
 
 @Entity('projects')
 export class Project {
@@ -32,6 +34,9 @@ export class Project {
   @ManyToOne(() => Area, { onDelete: 'RESTRICT', nullable: false })
   @JoinColumn({ name: 'area_id' })
   area: Area;
+
+  @OneToMany(() => ProjectPhase, (phase) => phase.project)
+  phases: ProjectPhase[];
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/apps/backend/src/projects/projects.controller.spec.ts
+++ b/apps/backend/src/projects/projects.controller.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Area } from '../area/entities/area.entity';
+import { CreateProjectPhaseDto } from './dto/create-project-phase.dto';
 import { CreateProjectDto } from './dto/create-project.dto';
+import { ReorderProjectPhasesDto } from './dto/reorder-project-phases.dto';
+import { UpdateProjectPhaseDto } from './dto/update-project-phase.dto';
+import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
@@ -11,6 +15,20 @@ const createArea = (overrides: Partial<Area> = {}): Area => ({
   description: null,
   isArchived: false,
   memberships: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const createProjectPhase = (
+  overrides: Partial<ProjectPhase> = {},
+): ProjectPhase => ({
+  id: 1,
+  name: 'Planning',
+  description: null,
+  orderIndex: 1,
+  projectId: 1,
+  project: {} as Project,
   createdAt: new Date(),
   updatedAt: new Date(),
   ...overrides,
@@ -27,6 +45,7 @@ const createProject = (overrides: Partial<Project> = {}): Project => {
     endDate: '2026-07-01',
     areaId: area.id,
     area,
+    phases: [],
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -39,6 +58,12 @@ describe('ProjectsController', () => {
   const mockProjectsService = {
     create: jest.fn(),
     findAll: jest.fn(),
+    findOne: jest.fn(),
+    findPhases: jest.fn(),
+    createPhase: jest.fn(),
+    updatePhase: jest.fn(),
+    reorderPhases: jest.fn(),
+    deletePhase: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -91,5 +116,89 @@ describe('ProjectsController', () => {
 
     await expect(controller.findAll(paginationDto)).resolves.toEqual(response);
     expect(mockProjectsService.findAll).toHaveBeenCalledWith(paginationDto);
+  });
+
+  it('gets project detail through the service', async () => {
+    const project = createProject({ phases: [createProjectPhase()] });
+
+    mockProjectsService.findOne.mockResolvedValue(project);
+
+    await expect(controller.findOne(1)).resolves.toEqual(project);
+    expect(mockProjectsService.findOne).toHaveBeenCalledWith(1);
+  });
+
+  it('lists project phases through the service', async () => {
+    const phases = [createProjectPhase()];
+
+    mockProjectsService.findPhases.mockResolvedValue(phases);
+
+    await expect(controller.findPhases(1)).resolves.toEqual(phases);
+    expect(mockProjectsService.findPhases).toHaveBeenCalledWith(1);
+  });
+
+  it('creates project phases through the service', async () => {
+    const createProjectPhaseDto: CreateProjectPhaseDto = {
+      name: 'Retrospective',
+      description: 'Closeout notes',
+    };
+    const phase = createProjectPhase({
+      name: 'Retrospective',
+      description: 'Closeout notes',
+    });
+
+    mockProjectsService.createPhase.mockResolvedValue(phase);
+
+    await expect(
+      controller.createPhase(1, createProjectPhaseDto),
+    ).resolves.toEqual(phase);
+    expect(mockProjectsService.createPhase).toHaveBeenCalledWith(
+      1,
+      createProjectPhaseDto,
+    );
+  });
+
+  it('updates project phases through the service', async () => {
+    const updateProjectPhaseDto: UpdateProjectPhaseDto = {
+      name: 'Discovery',
+    };
+    const phase = createProjectPhase({ name: 'Discovery' });
+
+    mockProjectsService.updatePhase.mockResolvedValue(phase);
+
+    await expect(
+      controller.updatePhase(1, 2, updateProjectPhaseDto),
+    ).resolves.toEqual(phase);
+    expect(mockProjectsService.updatePhase).toHaveBeenCalledWith(
+      1,
+      2,
+      updateProjectPhaseDto,
+    );
+  });
+
+  it('reorders project phases through the service', async () => {
+    const reorderProjectPhasesDto: ReorderProjectPhasesDto = {
+      phaseIds: [2, 1],
+    };
+    const phases = [
+      createProjectPhase({ id: 2, orderIndex: 1 }),
+      createProjectPhase({ id: 1, orderIndex: 2 }),
+    ];
+
+    mockProjectsService.reorderPhases.mockResolvedValue(phases);
+
+    await expect(
+      controller.reorderPhases(1, reorderProjectPhasesDto),
+    ).resolves.toEqual(phases);
+    expect(mockProjectsService.reorderPhases).toHaveBeenCalledWith(
+      1,
+      reorderProjectPhasesDto,
+    );
+  });
+
+  it('deletes project phases through the service', async () => {
+    mockProjectsService.deletePhase.mockResolvedValue(undefined);
+
+    await expect(controller.deletePhase(1, 2)).resolves.toBeUndefined();
+    expect(mockProjectsService.deletePhase).toHaveBeenCalledWith(1, 2);
   });
 });

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -1,6 +1,19 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { PaginationDto } from '../common/dto/pagination.dto';
+import { CreateProjectPhaseDto } from './dto/create-project-phase.dto';
 import { CreateProjectDto } from './dto/create-project.dto';
+import { ReorderProjectPhasesDto } from './dto/reorder-project-phases.dto';
+import { UpdateProjectPhaseDto } from './dto/update-project-phase.dto';
 import { ProjectsService } from './projects.service';
 
 // TODO: Add project permissions once the access rules are defined.
@@ -16,5 +29,55 @@ export class ProjectsController {
   @Get()
   findAll(@Query() paginationDto: PaginationDto) {
     return this.projectsService.findAll(paginationDto);
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.projectsService.findOne(id);
+  }
+
+  @Get(':projectId/phases')
+  findPhases(@Param('projectId', ParseIntPipe) projectId: number) {
+    return this.projectsService.findPhases(projectId);
+  }
+
+  @Post(':projectId/phases')
+  createPhase(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Body() createProjectPhaseDto: CreateProjectPhaseDto,
+  ) {
+    return this.projectsService.createPhase(projectId, createProjectPhaseDto);
+  }
+
+  @Patch(':projectId/phases/reorder')
+  reorderPhases(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Body() reorderProjectPhasesDto: ReorderProjectPhasesDto,
+  ) {
+    return this.projectsService.reorderPhases(
+      projectId,
+      reorderProjectPhasesDto,
+    );
+  }
+
+  @Patch(':projectId/phases/:phaseId')
+  updatePhase(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Param('phaseId', ParseIntPipe) phaseId: number,
+    @Body() updateProjectPhaseDto: UpdateProjectPhaseDto,
+  ) {
+    return this.projectsService.updatePhase(
+      projectId,
+      phaseId,
+      updateProjectPhaseDto,
+    );
+  }
+
+  @Delete(':projectId/phases/:phaseId')
+  deletePhase(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Param('phaseId', ParseIntPipe) phaseId: number,
+  ) {
+    return this.projectsService.deletePhase(projectId, phaseId);
   }
 }

--- a/apps/backend/src/projects/projects.module.ts
+++ b/apps/backend/src/projects/projects.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AreaModule } from '../area/area.module';
+import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 
 @Module({
-  imports: [AreaModule, TypeOrmModule.forFeature([Project])],
+  imports: [AreaModule, TypeOrmModule.forFeature([Project, ProjectPhase])],
   controllers: [ProjectsController],
   providers: [ProjectsService],
   exports: [ProjectsService],

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -380,6 +380,13 @@ describe('ProjectsService', () => {
         description: 'Closeout notes',
       }),
     ).resolves.toEqual(phase);
+    expect(projectPhasesRepository.manager.transaction).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(projectsRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 1 },
+      lock: { mode: 'pessimistic_write' },
+    });
     expect(projectPhasesRepository.findOne).toHaveBeenCalledWith({
       where: { projectId: 1 },
       order: { orderIndex: 'DESC' },

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -102,6 +102,7 @@ describe('ProjectsService', () => {
         createProjectPhase(phase),
       ),
       save: jest.fn(),
+      update: jest.fn(),
       find: jest.fn(),
       findOne: jest.fn(),
       remove: jest.fn(),
@@ -406,8 +407,10 @@ describe('ProjectsService', () => {
       description: 'Initial work',
     });
 
-    projectPhasesRepository.findOne?.mockResolvedValue(phase);
-    projectPhasesRepository.save?.mockResolvedValue(updatedPhase);
+    projectPhasesRepository.findOne
+      ?.mockResolvedValueOnce(phase)
+      .mockResolvedValueOnce(updatedPhase);
+    projectPhasesRepository.update?.mockResolvedValue({ affected: 1 });
 
     await expect(
       service.updatePhase(1, 1, {
@@ -418,11 +421,26 @@ describe('ProjectsService', () => {
     expect(projectPhasesRepository.findOne).toHaveBeenCalledWith({
       where: { id: 1, projectId: 1 },
     });
-    expect(projectPhasesRepository.save).toHaveBeenCalledWith({
-      ...phase,
-      name: 'Discovery',
-      description: 'Initial work',
-    });
+    expect(projectPhasesRepository.update).toHaveBeenCalledWith(
+      { id: 1, projectId: 1 },
+      {
+        name: 'Discovery',
+        description: 'Initial work',
+      },
+    );
+    expect(projectPhasesRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('returns existing phases without updating when phase updates are empty', async () => {
+    const phase = createProjectPhase();
+
+    projectPhasesRepository.findOne
+      ?.mockResolvedValueOnce(phase)
+      .mockResolvedValueOnce(phase);
+
+    await expect(service.updatePhase(1, 1, {})).resolves.toEqual(phase);
+    expect(projectPhasesRepository.update).not.toHaveBeenCalled();
+    expect(projectPhasesRepository.save).not.toHaveBeenCalled();
   });
 
   it('reorders phases when every phase id is included exactly once', async () => {
@@ -437,10 +455,17 @@ describe('ProjectsService', () => {
       { ...phases[0], orderIndex: 2 },
       { ...phases[1], orderIndex: 3 },
     ];
+    const reorderedPhaseUpdates = [
+      { id: 3, orderIndex: 1 },
+      { id: 1, orderIndex: 2 },
+      { id: 2, orderIndex: 3 },
+    ];
 
     projectsRepository.findOne?.mockResolvedValue(project);
-    projectPhasesRepository.find?.mockResolvedValue(phases);
-    projectPhasesRepository.save?.mockResolvedValue(reorderedPhases);
+    projectPhasesRepository.find
+      ?.mockResolvedValueOnce(phases)
+      .mockResolvedValueOnce(reorderedPhases);
+    projectPhasesRepository.save?.mockResolvedValue(reorderedPhaseUpdates);
 
     await expect(
       service.reorderPhases(1, { phaseIds: [3, 1, 2] }),
@@ -452,7 +477,9 @@ describe('ProjectsService', () => {
       where: { id: 1 },
       lock: { mode: 'pessimistic_write' },
     });
-    expect(projectPhasesRepository.save).toHaveBeenCalledWith(reorderedPhases);
+    expect(projectPhasesRepository.save).toHaveBeenCalledWith(
+      reorderedPhaseUpdates,
+    );
   });
 
   it('rejects phase reorder requests that omit or include unknown phases', async () => {
@@ -482,15 +509,15 @@ describe('ProjectsService', () => {
       createProjectPhase({ id: 2, name: 'Execution', orderIndex: 2 }),
       createProjectPhase({ id: 3, name: 'Review', orderIndex: 3 }),
     ];
-    const remainingPhases = [
-      { ...phases[0], orderIndex: 1 },
-      { ...phases[2], orderIndex: 2 },
+    const remainingPhaseUpdates = [
+      { id: 1, orderIndex: 1 },
+      { id: 3, orderIndex: 2 },
     ];
 
     projectsRepository.findOne?.mockResolvedValue(project);
     projectPhasesRepository.find?.mockResolvedValue(phases);
     projectPhasesRepository.remove?.mockResolvedValue(phases[1]);
-    projectPhasesRepository.save?.mockResolvedValue(remainingPhases);
+    projectPhasesRepository.save?.mockResolvedValue(remainingPhaseUpdates);
 
     await expect(service.deletePhase(1, 2)).resolves.toBeUndefined();
     expect(projectPhasesRepository.manager.transaction).toHaveBeenCalledTimes(
@@ -501,7 +528,9 @@ describe('ProjectsService', () => {
       lock: { mode: 'pessimistic_write' },
     });
     expect(projectPhasesRepository.remove).toHaveBeenCalledWith(phases[1]);
-    expect(projectPhasesRepository.save).toHaveBeenCalledWith(remainingPhases);
+    expect(projectPhasesRepository.save).toHaveBeenCalledWith(
+      remainingPhaseUpdates,
+    );
   });
 
   it('rejects deleting the last project phase', async () => {

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -445,6 +445,13 @@ describe('ProjectsService', () => {
     await expect(
       service.reorderPhases(1, { phaseIds: [3, 1, 2] }),
     ).resolves.toEqual(reorderedPhases);
+    expect(projectPhasesRepository.manager.transaction).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(projectsRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 1 },
+      lock: { mode: 'pessimistic_write' },
+    });
     expect(projectPhasesRepository.save).toHaveBeenCalledWith(reorderedPhases);
   });
 
@@ -489,6 +496,10 @@ describe('ProjectsService', () => {
     expect(projectPhasesRepository.manager.transaction).toHaveBeenCalledTimes(
       1,
     );
+    expect(projectsRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 1 },
+      lock: { mode: 'pessimistic_write' },
+    });
     expect(projectPhasesRepository.remove).toHaveBeenCalledWith(phases[1]);
     expect(projectPhasesRepository.save).toHaveBeenCalledWith(remainingPhases);
   });

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -4,12 +4,17 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AreaService } from '../area/area.service';
 import { Area } from '../area/entities/area.entity';
+import { DEFAULT_PROJECT_PHASES } from './constants/default-project-phases.constant';
 import { CreateProjectDto } from './dto/create-project.dto';
+import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 import { ProjectsService } from './projects.service';
 
 type ProjectRepositoryMock = Partial<
   Record<keyof Repository<Project>, jest.Mock>
+>;
+type ProjectPhaseRepositoryMock = Partial<
+  Record<keyof Repository<ProjectPhase>, jest.Mock>
 >;
 
 const createArea = (overrides: Partial<Area> = {}): Area => ({
@@ -18,6 +23,20 @@ const createArea = (overrides: Partial<Area> = {}): Area => ({
   description: null,
   isArchived: false,
   memberships: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const createProjectPhase = (
+  overrides: Partial<ProjectPhase> = {},
+): ProjectPhase => ({
+  id: 1,
+  name: 'Planning',
+  description: null,
+  orderIndex: 1,
+  projectId: 1,
+  project: {} as Project,
   createdAt: new Date(),
   updatedAt: new Date(),
   ...overrides,
@@ -34,6 +53,7 @@ const createProject = (overrides: Partial<Project> = {}): Project => {
     endDate: '2026-07-01',
     areaId: area.id,
     area,
+    phases: [],
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -43,6 +63,7 @@ const createProject = (overrides: Partial<Project> = {}): Project => {
 describe('ProjectsService', () => {
   let service: ProjectsService;
   let projectsRepository: ProjectRepositoryMock;
+  let projectPhasesRepository: ProjectPhaseRepositoryMock;
 
   const mockAreaService = {
     findOne: jest.fn(),
@@ -63,6 +84,16 @@ describe('ProjectsService', () => {
       create: jest.fn(),
       save: jest.fn(),
       findAndCount: jest.fn(),
+      findOne: jest.fn(),
+    };
+    projectPhasesRepository = {
+      create: jest.fn((phase: Partial<ProjectPhase>) =>
+        createProjectPhase(phase),
+      ),
+      save: jest.fn(),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      remove: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -71,6 +102,10 @@ describe('ProjectsService', () => {
         {
           provide: getRepositoryToken(Project),
           useValue: projectsRepository,
+        },
+        {
+          provide: getRepositoryToken(ProjectPhase),
+          useValue: projectPhasesRepository,
         },
         {
           provide: AreaService,
@@ -82,15 +117,22 @@ describe('ProjectsService', () => {
     service = module.get<ProjectsService>(ProjectsService);
   });
 
-  it('creates a project when the area exists', async () => {
+  it('creates a project with default phases when the area exists', async () => {
     const area = createArea();
     const project = createProject({ area });
+    const phases = DEFAULT_PROJECT_PHASES.map((name, index) =>
+      createProjectPhase({ id: index + 1, name, orderIndex: index + 1 }),
+    );
 
     mockAreaService.findOne.mockResolvedValue(area);
     projectsRepository.create?.mockReturnValue(project);
     projectsRepository.save?.mockResolvedValue(project);
+    projectPhasesRepository.save?.mockResolvedValue(phases);
 
-    await expect(service.create(createProjectDto)).resolves.toEqual(project);
+    await expect(service.create(createProjectDto)).resolves.toEqual({
+      ...project,
+      phases,
+    });
     expect(mockAreaService.findOne).toHaveBeenCalledWith(1);
     expect(projectsRepository.create).toHaveBeenCalledWith({
       name: createProjectDto.name,
@@ -100,7 +142,49 @@ describe('ProjectsService', () => {
       areaId: area.id,
       area,
     });
+    expect(projectPhasesRepository.create).toHaveBeenCalledTimes(
+      DEFAULT_PROJECT_PHASES.length,
+    );
+    DEFAULT_PROJECT_PHASES.forEach((name, index) => {
+      expect(projectPhasesRepository.create).toHaveBeenCalledWith({
+        name,
+        description: null,
+        orderIndex: index + 1,
+        projectId: project.id,
+        project,
+      });
+    });
     expect(projectsRepository.save).toHaveBeenCalledWith(project);
+    expect(projectPhasesRepository.save).toHaveBeenCalledWith([
+      expect.objectContaining({
+        name: 'Planning',
+        description: null,
+        orderIndex: 1,
+        projectId: project.id,
+        project,
+      }),
+      expect.objectContaining({
+        name: 'Execution',
+        description: null,
+        orderIndex: 2,
+        projectId: project.id,
+        project,
+      }),
+      expect.objectContaining({
+        name: 'Review',
+        description: null,
+        orderIndex: 3,
+        projectId: project.id,
+        project,
+      }),
+      expect.objectContaining({
+        name: 'Launch',
+        description: null,
+        orderIndex: 4,
+        projectId: project.id,
+        project,
+      }),
+    ]);
   });
 
   it('stores nullable optional fields when they are omitted', async () => {
@@ -111,17 +195,22 @@ describe('ProjectsService', () => {
       endDate: null,
       area,
     });
+    const phases = [createProjectPhase()];
 
     mockAreaService.findOne.mockResolvedValue(area);
     projectsRepository.create?.mockReturnValue(project);
     projectsRepository.save?.mockResolvedValue(project);
+    projectPhasesRepository.save?.mockResolvedValue(phases);
 
     await expect(
       service.create({
         name: 'Proyecto sin fechas',
         areaId: 1,
       }),
-    ).resolves.toEqual(project);
+    ).resolves.toEqual({
+      ...project,
+      phases,
+    });
     expect(projectsRepository.create).toHaveBeenCalledWith({
       name: 'Proyecto sin fechas',
       description: null,
@@ -145,6 +234,7 @@ describe('ProjectsService', () => {
     ).rejects.toBeInstanceOf(NotFoundException);
     expect(projectsRepository.create).not.toHaveBeenCalled();
     expect(projectsRepository.save).not.toHaveBeenCalled();
+    expect(projectPhasesRepository.save).not.toHaveBeenCalled();
   });
 
   it('rejects projects with an end date before the start date', async () => {
@@ -200,5 +290,187 @@ describe('ProjectsService', () => {
       skip: 0,
       take: 10,
     });
+  });
+
+  it('returns project detail with phases ordered by order index', async () => {
+    const project = createProject({
+      phases: [
+        createProjectPhase({ id: 1, orderIndex: 1 }),
+        createProjectPhase({ id: 2, name: 'Execution', orderIndex: 2 }),
+      ],
+    });
+
+    projectsRepository.findOne?.mockResolvedValue(project);
+
+    await expect(service.findOne(1)).resolves.toEqual(project);
+    expect(projectsRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 1 },
+      relations: ['area', 'phases'],
+      order: {
+        phases: {
+          orderIndex: 'ASC',
+        },
+      },
+    });
+  });
+
+  it('rejects project detail when the project does not exist', async () => {
+    projectsRepository.findOne?.mockResolvedValue(null);
+
+    await expect(service.findOne(99)).rejects.toThrow(
+      new NotFoundException('Project with ID 99 not found'),
+    );
+  });
+
+  it('lists phases for an existing project', async () => {
+    const project = createProject();
+    const phases = [createProjectPhase(), createProjectPhase({ id: 2 })];
+
+    projectsRepository.findOne?.mockResolvedValue(project);
+    projectPhasesRepository.find?.mockResolvedValue(phases);
+
+    await expect(service.findPhases(1)).resolves.toEqual(phases);
+    expect(projectPhasesRepository.find).toHaveBeenCalledWith({
+      where: { projectId: 1 },
+      order: { orderIndex: 'ASC' },
+    });
+  });
+
+  it('creates custom phases after the current last phase', async () => {
+    const project = createProject();
+    const lastPhase = createProjectPhase({ orderIndex: 4 });
+    const phase = createProjectPhase({
+      id: 5,
+      name: 'Retrospective',
+      description: 'Closeout notes',
+      orderIndex: 5,
+    });
+
+    projectsRepository.findOne?.mockResolvedValue(project);
+    projectPhasesRepository.findOne?.mockResolvedValue(lastPhase);
+    projectPhasesRepository.create?.mockReturnValue(phase);
+    projectPhasesRepository.save?.mockResolvedValue(phase);
+
+    await expect(
+      service.createPhase(1, {
+        name: 'Retrospective',
+        description: 'Closeout notes',
+      }),
+    ).resolves.toEqual(phase);
+    expect(projectPhasesRepository.findOne).toHaveBeenCalledWith({
+      where: { projectId: 1 },
+      order: { orderIndex: 'DESC' },
+    });
+    expect(projectPhasesRepository.create).toHaveBeenCalledWith({
+      name: 'Retrospective',
+      description: 'Closeout notes',
+      orderIndex: 5,
+      projectId: project.id,
+      project,
+    });
+  });
+
+  it('updates phase names and descriptions', async () => {
+    const phase = createProjectPhase();
+    const updatedPhase = createProjectPhase({
+      name: 'Discovery',
+      description: 'Initial work',
+    });
+
+    projectPhasesRepository.findOne?.mockResolvedValue(phase);
+    projectPhasesRepository.save?.mockResolvedValue(updatedPhase);
+
+    await expect(
+      service.updatePhase(1, 1, {
+        name: 'Discovery',
+        description: 'Initial work',
+      }),
+    ).resolves.toEqual(updatedPhase);
+    expect(projectPhasesRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 1, projectId: 1 },
+    });
+    expect(projectPhasesRepository.save).toHaveBeenCalledWith({
+      ...phase,
+      name: 'Discovery',
+      description: 'Initial work',
+    });
+  });
+
+  it('reorders phases when every phase id is included exactly once', async () => {
+    const project = createProject();
+    const phases = [
+      createProjectPhase({ id: 1, orderIndex: 1 }),
+      createProjectPhase({ id: 2, name: 'Execution', orderIndex: 2 }),
+      createProjectPhase({ id: 3, name: 'Review', orderIndex: 3 }),
+    ];
+    const reorderedPhases = [
+      { ...phases[2], orderIndex: 1 },
+      { ...phases[0], orderIndex: 2 },
+      { ...phases[1], orderIndex: 3 },
+    ];
+
+    projectsRepository.findOne?.mockResolvedValue(project);
+    projectPhasesRepository.find?.mockResolvedValue(phases);
+    projectPhasesRepository.save?.mockResolvedValue(reorderedPhases);
+
+    await expect(
+      service.reorderPhases(1, { phaseIds: [3, 1, 2] }),
+    ).resolves.toEqual(reorderedPhases);
+    expect(projectPhasesRepository.save).toHaveBeenCalledWith(reorderedPhases);
+  });
+
+  it('rejects phase reorder requests that omit or include unknown phases', async () => {
+    const project = createProject();
+    const phases = [
+      createProjectPhase({ id: 1, orderIndex: 1 }),
+      createProjectPhase({ id: 2, name: 'Execution', orderIndex: 2 }),
+    ];
+
+    projectsRepository.findOne?.mockResolvedValue(project);
+    projectPhasesRepository.find?.mockResolvedValue(phases);
+
+    await expect(
+      service.reorderPhases(1, { phaseIds: [1, 99] }),
+    ).rejects.toThrow(
+      new BadRequestException(
+        'phaseIds must include every project phase exactly once',
+      ),
+    );
+    expect(projectPhasesRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('deletes a phase and compacts remaining phase order', async () => {
+    const project = createProject();
+    const phases = [
+      createProjectPhase({ id: 1, orderIndex: 1 }),
+      createProjectPhase({ id: 2, name: 'Execution', orderIndex: 2 }),
+      createProjectPhase({ id: 3, name: 'Review', orderIndex: 3 }),
+    ];
+    const remainingPhases = [
+      { ...phases[0], orderIndex: 1 },
+      { ...phases[2], orderIndex: 2 },
+    ];
+
+    projectsRepository.findOne?.mockResolvedValue(project);
+    projectPhasesRepository.find?.mockResolvedValue(phases);
+    projectPhasesRepository.remove?.mockResolvedValue(phases[1]);
+    projectPhasesRepository.save?.mockResolvedValue(remainingPhases);
+
+    await expect(service.deletePhase(1, 2)).resolves.toBeUndefined();
+    expect(projectPhasesRepository.remove).toHaveBeenCalledWith(phases[1]);
+    expect(projectPhasesRepository.save).toHaveBeenCalledWith(remainingPhases);
+  });
+
+  it('rejects deleting the last project phase', async () => {
+    const project = createProject();
+    const phases = [createProjectPhase()];
+
+    projectsRepository.findOne?.mockResolvedValue(project);
+    projectPhasesRepository.find?.mockResolvedValue(phases);
+
+    await expect(service.deletePhase(1, 1)).rejects.toThrow(
+      new BadRequestException('Projects must keep at least one phase'),
+    );
+    expect(projectPhasesRepository.remove).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -502,6 +502,26 @@ describe('ProjectsService', () => {
     expect(projectPhasesRepository.save).not.toHaveBeenCalled();
   });
 
+  it('rejects phase reorder requests with duplicate phase ids', async () => {
+    const project = createProject();
+    const phases = [
+      createProjectPhase({ id: 1, orderIndex: 1 }),
+      createProjectPhase({ id: 2, name: 'Execution', orderIndex: 2 }),
+    ];
+
+    projectsRepository.findOne?.mockResolvedValue(project);
+    projectPhasesRepository.find?.mockResolvedValue(phases);
+
+    await expect(
+      service.reorderPhases(1, { phaseIds: [1, 1] }),
+    ).rejects.toThrow(
+      new BadRequestException(
+        'phaseIds must include every project phase exactly once',
+      ),
+    );
+    expect(projectPhasesRepository.save).not.toHaveBeenCalled();
+  });
+
   it('deletes a phase and compacts remaining phase order', async () => {
     const project = createProject();
     const phases = [

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { ObjectLiteral, Repository } from 'typeorm';
 import { AreaService } from '../area/area.service';
 import { Area } from '../area/entities/area.entity';
 import { DEFAULT_PROJECT_PHASES } from './constants/default-project-phases.constant';
@@ -10,12 +10,20 @@ import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 import { ProjectsService } from './projects.service';
 
-type ProjectRepositoryMock = Partial<
-  Record<keyof Repository<Project>, jest.Mock>
+type RepositoryMethodMocks<T extends ObjectLiteral> = Partial<
+  Record<Exclude<keyof Repository<T>, 'manager'>, jest.Mock>
 >;
-type ProjectPhaseRepositoryMock = Partial<
-  Record<keyof Repository<ProjectPhase>, jest.Mock>
->;
+
+type ProjectRepositoryMock = RepositoryMethodMocks<Project> & {
+  manager: {
+    transaction: jest.Mock;
+  };
+};
+type ProjectPhaseRepositoryMock = RepositoryMethodMocks<ProjectPhase> & {
+  manager: {
+    transaction: jest.Mock;
+  };
+};
 
 const createArea = (overrides: Partial<Area> = {}): Area => ({
   id: 1,
@@ -85,6 +93,9 @@ describe('ProjectsService', () => {
       save: jest.fn(),
       findAndCount: jest.fn(),
       findOne: jest.fn(),
+      manager: {
+        transaction: jest.fn(),
+      },
     };
     projectPhasesRepository = {
       create: jest.fn((phase: Partial<ProjectPhase>) =>
@@ -94,7 +105,23 @@ describe('ProjectsService', () => {
       find: jest.fn(),
       findOne: jest.fn(),
       remove: jest.fn(),
+      manager: {
+        transaction: jest.fn(),
+      },
     };
+    const getRepository = jest.fn(
+      (entity: typeof Project | typeof ProjectPhase) =>
+        entity === Project ? projectsRepository : projectPhasesRepository,
+    );
+    const transaction = jest.fn(
+      async (
+        callback: (entityManager: {
+          getRepository: typeof getRepository;
+        }) => Promise<unknown>,
+      ) => callback({ getRepository }),
+    );
+    projectsRepository.manager.transaction = transaction;
+    projectPhasesRepository.manager.transaction = transaction;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -151,38 +178,34 @@ describe('ProjectsService', () => {
         description: null,
         orderIndex: index + 1,
         projectId: project.id,
-        project,
       });
     });
     expect(projectsRepository.save).toHaveBeenCalledWith(project);
+    expect(projectsRepository.manager.transaction).toHaveBeenCalledTimes(1);
     expect(projectPhasesRepository.save).toHaveBeenCalledWith([
       expect.objectContaining({
         name: 'Planning',
         description: null,
         orderIndex: 1,
         projectId: project.id,
-        project,
       }),
       expect.objectContaining({
         name: 'Execution',
         description: null,
         orderIndex: 2,
         projectId: project.id,
-        project,
       }),
       expect.objectContaining({
         name: 'Review',
         description: null,
         orderIndex: 3,
         projectId: project.id,
-        project,
       }),
       expect.objectContaining({
         name: 'Launch',
         description: null,
         orderIndex: 4,
         projectId: project.id,
-        project,
       }),
     ]);
   });
@@ -366,7 +389,6 @@ describe('ProjectsService', () => {
       description: 'Closeout notes',
       orderIndex: 5,
       projectId: project.id,
-      project,
     });
   });
 
@@ -457,6 +479,9 @@ describe('ProjectsService', () => {
     projectPhasesRepository.save?.mockResolvedValue(remainingPhases);
 
     await expect(service.deletePhase(1, 2)).resolves.toBeUndefined();
+    expect(projectPhasesRepository.manager.transaction).toHaveBeenCalledTimes(
+      1,
+    );
     expect(projectPhasesRepository.remove).toHaveBeenCalledWith(phases[1]);
     expect(projectPhasesRepository.save).toHaveBeenCalledWith(remainingPhases);
   });

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -111,16 +111,45 @@ export class ProjectsService {
     projectId: number,
     createProjectPhaseDto: CreateProjectPhaseDto,
   ): Promise<ProjectPhase> {
-    const project = await this.ensureProjectExists(projectId);
-    const nextOrderIndex = await this.getNextPhaseOrderIndex(projectId);
-    const phase = this.projectPhasesRepository.create({
-      name: createProjectPhaseDto.name,
-      description: createProjectPhaseDto.description ?? null,
-      orderIndex: nextOrderIndex,
-      projectId: project.id,
+    return this.projectPhasesRepository.manager.transaction(
+      async (entityManager) => {
+        const projectsRepository = entityManager.getRepository(Project);
+        const projectPhasesRepository =
+          entityManager.getRepository(ProjectPhase);
+        const project = await this.findProjectForUpdate(
+          projectId,
+          projectsRepository,
+        );
+        const nextOrderIndex = await this.getNextPhaseOrderIndex(
+          projectId,
+          projectPhasesRepository,
+        );
+        const phase = projectPhasesRepository.create({
+          name: createProjectPhaseDto.name,
+          description: createProjectPhaseDto.description ?? null,
+          orderIndex: nextOrderIndex,
+          projectId: project.id,
+        });
+
+        return projectPhasesRepository.save(phase);
+      },
+    );
+  }
+
+  private async findProjectForUpdate(
+    projectId: number,
+    projectsRepository: Repository<Project>,
+  ): Promise<Project> {
+    const project = await projectsRepository.findOne({
+      where: { id: projectId },
+      lock: { mode: 'pessimistic_write' },
     });
 
-    return this.projectPhasesRepository.save(phase);
+    if (!project) {
+      throw new NotFoundException(`Project with ID ${projectId} not found`);
+    }
+
+    return project;
   }
 
   async updatePhase(
@@ -260,8 +289,12 @@ export class ProjectsService {
     return phase;
   }
 
-  private async getNextPhaseOrderIndex(projectId: number): Promise<number> {
-    const lastPhase = await this.projectPhasesRepository.findOne({
+  private async getNextPhaseOrderIndex(
+    projectId: number,
+    projectPhasesRepository: Repository<ProjectPhase> = this
+      .projectPhasesRepository,
+  ): Promise<number> {
+    const lastPhase = await projectPhasesRepository.findOne({
       where: { projectId },
       order: { orderIndex: 'DESC' },
     });

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -154,17 +154,25 @@ export class ProjectsService {
     phaseId: number,
     updateProjectPhaseDto: UpdateProjectPhaseDto,
   ): Promise<ProjectPhase> {
-    const phase = await this.findPhaseOrThrow(projectId, phaseId);
+    await this.findPhaseOrThrow(projectId, phaseId);
+    const phaseUpdate: Partial<Pick<ProjectPhase, 'name' | 'description'>> = {};
 
     if (updateProjectPhaseDto.name !== undefined) {
-      phase.name = updateProjectPhaseDto.name;
+      phaseUpdate.name = updateProjectPhaseDto.name;
     }
 
     if (updateProjectPhaseDto.description !== undefined) {
-      phase.description = updateProjectPhaseDto.description;
+      phaseUpdate.description = updateProjectPhaseDto.description;
     }
 
-    return this.projectPhasesRepository.save(phase);
+    if (Object.keys(phaseUpdate).length > 0) {
+      await this.projectPhasesRepository.update(
+        { id: phaseId, projectId },
+        phaseUpdate,
+      );
+    }
+
+    return this.findPhaseOrThrow(projectId, phaseId);
   }
 
   async reorderPhases(
@@ -197,11 +205,15 @@ export class ProjectsService {
 
         const reorderedPhases = phaseIds.map((phaseId, index) => {
           const phase = phasesById.get(phaseId) as ProjectPhase;
-          phase.orderIndex = index + 1;
-          return phase;
+          return {
+            id: phase.id,
+            orderIndex: index + 1,
+          };
         });
 
-        return projectPhasesRepository.save(reorderedPhases);
+        await projectPhasesRepository.save(reorderedPhases);
+
+        return this.findProjectPhases(projectId, projectPhasesRepository);
       },
     );
   }
@@ -238,8 +250,10 @@ export class ProjectsService {
         const remainingPhases = phases
           .filter((currentPhase) => currentPhase.id !== phaseId)
           .map((currentPhase, index) => {
-            currentPhase.orderIndex = index + 1;
-            return currentPhase;
+            return {
+              id: currentPhase.id,
+              orderIndex: index + 1,
+            };
           });
 
         await projectPhasesRepository.remove(phase);

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -39,10 +39,20 @@ export class ProjectsService {
       area,
     });
 
-    const savedProject = await this.projectsRepository.save(project);
-    savedProject.phases = await this.createDefaultPhases(savedProject);
+    return this.projectsRepository.manager.transaction(
+      async (entityManager) => {
+        const savedProject = await entityManager
+          .getRepository(Project)
+          .save(project);
 
-    return savedProject;
+        savedProject.phases = await this.createDefaultPhases(
+          savedProject,
+          entityManager.getRepository(ProjectPhase),
+        );
+
+        return savedProject;
+      },
+    );
   }
 
   async findAll(
@@ -108,7 +118,6 @@ export class ProjectsService {
       description: createProjectPhaseDto.description ?? null,
       orderIndex: nextOrderIndex,
       projectId: project.id,
-      project,
     });
 
     return this.projectPhasesRepository.save(phase);
@@ -174,8 +183,6 @@ export class ProjectsService {
       throw new BadRequestException('Projects must keep at least one phase');
     }
 
-    await this.projectPhasesRepository.remove(phase);
-
     const remainingPhases = phases
       .filter((currentPhase) => currentPhase.id !== phaseId)
       .map((currentPhase, index) => {
@@ -183,7 +190,15 @@ export class ProjectsService {
         return currentPhase;
       });
 
-    await this.projectPhasesRepository.save(remainingPhases);
+    await this.projectPhasesRepository.manager.transaction(
+      async (entityManager) => {
+        const projectPhasesRepository =
+          entityManager.getRepository(ProjectPhase);
+
+        await projectPhasesRepository.remove(phase);
+        await projectPhasesRepository.save(remainingPhases);
+      },
+    );
   }
 
   private validateDateRange(createProjectDto: CreateProjectDto): void {
@@ -200,18 +215,20 @@ export class ProjectsService {
     }
   }
 
-  private createDefaultPhases(project: Project): Promise<ProjectPhase[]> {
+  private createDefaultPhases(
+    project: Project,
+    projectPhasesRepository: Repository<ProjectPhase>,
+  ): Promise<ProjectPhase[]> {
     const phases = DEFAULT_PROJECT_PHASES.map((name, index) =>
-      this.projectPhasesRepository.create({
+      projectPhasesRepository.create({
         name,
         description: null,
         orderIndex: index + 1,
         projectId: project.id,
-        project,
       }),
     );
 
-    return this.projectPhasesRepository.save(phases);
+    return projectPhasesRepository.save(phases);
   }
 
   private async ensureProjectExists(projectId: number): Promise<Project> {

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -101,10 +101,7 @@ export class ProjectsService {
   async findPhases(projectId: number): Promise<ProjectPhase[]> {
     await this.ensureProjectExists(projectId);
 
-    return this.projectPhasesRepository.find({
-      where: { projectId },
-      order: { orderIndex: 'ASC' },
-    });
+    return this.findProjectPhases(projectId);
   }
 
   async createPhase(
@@ -174,55 +171,76 @@ export class ProjectsService {
     projectId: number,
     reorderProjectPhasesDto: ReorderProjectPhasesDto,
   ): Promise<ProjectPhase[]> {
-    const phases = await this.findPhases(projectId);
-    const phaseIds = reorderProjectPhasesDto.phaseIds;
-    const phasesById = new Map(phases.map((phase) => [phase.id, phase]));
+    return this.projectPhasesRepository.manager.transaction(
+      async (entityManager) => {
+        await this.findProjectForUpdate(
+          projectId,
+          entityManager.getRepository(Project),
+        );
+        const projectPhasesRepository =
+          entityManager.getRepository(ProjectPhase);
+        const phases = await this.findProjectPhases(
+          projectId,
+          projectPhasesRepository,
+        );
+        const phaseIds = reorderProjectPhasesDto.phaseIds;
+        const phasesById = new Map(phases.map((phase) => [phase.id, phase]));
 
-    if (
-      phases.length !== phaseIds.length ||
-      phaseIds.some((phaseId) => !phasesById.has(phaseId))
-    ) {
-      throw new BadRequestException(
-        'phaseIds must include every project phase exactly once',
-      );
-    }
+        if (
+          phases.length !== phaseIds.length ||
+          phaseIds.some((phaseId) => !phasesById.has(phaseId))
+        ) {
+          throw new BadRequestException(
+            'phaseIds must include every project phase exactly once',
+          );
+        }
 
-    const reorderedPhases = phaseIds.map((phaseId, index) => {
-      const phase = phasesById.get(phaseId) as ProjectPhase;
-      phase.orderIndex = index + 1;
-      return phase;
-    });
+        const reorderedPhases = phaseIds.map((phaseId, index) => {
+          const phase = phasesById.get(phaseId) as ProjectPhase;
+          phase.orderIndex = index + 1;
+          return phase;
+        });
 
-    await this.projectPhasesRepository.save(reorderedPhases);
-
-    return reorderedPhases;
+        return projectPhasesRepository.save(reorderedPhases);
+      },
+    );
   }
 
   async deletePhase(projectId: number, phaseId: number): Promise<void> {
-    const phases = await this.findPhases(projectId);
-    const phase = phases.find((currentPhase) => currentPhase.id === phaseId);
-
-    if (!phase) {
-      throw new NotFoundException(
-        `Project phase with ID ${phaseId} not found in project ${projectId}`,
-      );
-    }
-
-    if (phases.length === 1) {
-      throw new BadRequestException('Projects must keep at least one phase');
-    }
-
-    const remainingPhases = phases
-      .filter((currentPhase) => currentPhase.id !== phaseId)
-      .map((currentPhase, index) => {
-        currentPhase.orderIndex = index + 1;
-        return currentPhase;
-      });
-
     await this.projectPhasesRepository.manager.transaction(
       async (entityManager) => {
+        await this.findProjectForUpdate(
+          projectId,
+          entityManager.getRepository(Project),
+        );
         const projectPhasesRepository =
           entityManager.getRepository(ProjectPhase);
+        const phases = await this.findProjectPhases(
+          projectId,
+          projectPhasesRepository,
+        );
+        const phase = phases.find(
+          (currentPhase) => currentPhase.id === phaseId,
+        );
+
+        if (!phase) {
+          throw new NotFoundException(
+            `Project phase with ID ${phaseId} not found in project ${projectId}`,
+          );
+        }
+
+        if (phases.length === 1) {
+          throw new BadRequestException(
+            'Projects must keep at least one phase',
+          );
+        }
+
+        const remainingPhases = phases
+          .filter((currentPhase) => currentPhase.id !== phaseId)
+          .map((currentPhase, index) => {
+            currentPhase.orderIndex = index + 1;
+            return currentPhase;
+          });
 
         await projectPhasesRepository.remove(phase);
         await projectPhasesRepository.save(remainingPhases);
@@ -287,6 +305,17 @@ export class ProjectsService {
     }
 
     return phase;
+  }
+
+  private findProjectPhases(
+    projectId: number,
+    projectPhasesRepository: Repository<ProjectPhase> = this
+      .projectPhasesRepository,
+  ): Promise<ProjectPhase[]> {
+    return projectPhasesRepository.find({
+      where: { projectId },
+      order: { orderIndex: 'ASC' },
+    });
   }
 
   private async getNextPhaseOrderIndex(

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -192,10 +192,12 @@ export class ProjectsService {
           projectPhasesRepository,
         );
         const phaseIds = reorderProjectPhasesDto.phaseIds;
+        const uniquePhaseIds = new Set(phaseIds);
         const phasesById = new Map(phases.map((phase) => [phase.id, phase]));
 
         if (
           phases.length !== phaseIds.length ||
+          uniquePhaseIds.size !== phaseIds.length ||
           phaseIds.some((phaseId) => !phasesById.has(phaseId))
         ) {
           throw new BadRequestException(

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -1,10 +1,19 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AreaService } from '../area/area.service';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { PaginatedResponse } from '../common/interfaces/paginated-response.interface';
+import { DEFAULT_PROJECT_PHASES } from './constants/default-project-phases.constant';
+import { CreateProjectPhaseDto } from './dto/create-project-phase.dto';
 import { CreateProjectDto } from './dto/create-project.dto';
+import { ReorderProjectPhasesDto } from './dto/reorder-project-phases.dto';
+import { UpdateProjectPhaseDto } from './dto/update-project-phase.dto';
+import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 
 @Injectable()
@@ -12,6 +21,8 @@ export class ProjectsService {
   constructor(
     @InjectRepository(Project)
     private readonly projectsRepository: Repository<Project>,
+    @InjectRepository(ProjectPhase)
+    private readonly projectPhasesRepository: Repository<ProjectPhase>,
     private readonly areaService: AreaService,
   ) {}
 
@@ -28,7 +39,10 @@ export class ProjectsService {
       area,
     });
 
-    return this.projectsRepository.save(project);
+    const savedProject = await this.projectsRepository.save(project);
+    savedProject.phases = await this.createDefaultPhases(savedProject);
+
+    return savedProject;
   }
 
   async findAll(
@@ -56,6 +70,122 @@ export class ProjectsService {
     };
   }
 
+  async findOne(id: number): Promise<Project> {
+    const project = await this.projectsRepository.findOne({
+      where: { id },
+      relations: ['area', 'phases'],
+      order: {
+        phases: {
+          orderIndex: 'ASC',
+        },
+      },
+    });
+
+    if (!project) {
+      throw new NotFoundException(`Project with ID ${id} not found`);
+    }
+
+    return project;
+  }
+
+  async findPhases(projectId: number): Promise<ProjectPhase[]> {
+    await this.ensureProjectExists(projectId);
+
+    return this.projectPhasesRepository.find({
+      where: { projectId },
+      order: { orderIndex: 'ASC' },
+    });
+  }
+
+  async createPhase(
+    projectId: number,
+    createProjectPhaseDto: CreateProjectPhaseDto,
+  ): Promise<ProjectPhase> {
+    const project = await this.ensureProjectExists(projectId);
+    const nextOrderIndex = await this.getNextPhaseOrderIndex(projectId);
+    const phase = this.projectPhasesRepository.create({
+      name: createProjectPhaseDto.name,
+      description: createProjectPhaseDto.description ?? null,
+      orderIndex: nextOrderIndex,
+      projectId: project.id,
+      project,
+    });
+
+    return this.projectPhasesRepository.save(phase);
+  }
+
+  async updatePhase(
+    projectId: number,
+    phaseId: number,
+    updateProjectPhaseDto: UpdateProjectPhaseDto,
+  ): Promise<ProjectPhase> {
+    const phase = await this.findPhaseOrThrow(projectId, phaseId);
+
+    if (updateProjectPhaseDto.name !== undefined) {
+      phase.name = updateProjectPhaseDto.name;
+    }
+
+    if (updateProjectPhaseDto.description !== undefined) {
+      phase.description = updateProjectPhaseDto.description;
+    }
+
+    return this.projectPhasesRepository.save(phase);
+  }
+
+  async reorderPhases(
+    projectId: number,
+    reorderProjectPhasesDto: ReorderProjectPhasesDto,
+  ): Promise<ProjectPhase[]> {
+    const phases = await this.findPhases(projectId);
+    const phaseIds = reorderProjectPhasesDto.phaseIds;
+    const phasesById = new Map(phases.map((phase) => [phase.id, phase]));
+
+    if (
+      phases.length !== phaseIds.length ||
+      phaseIds.some((phaseId) => !phasesById.has(phaseId))
+    ) {
+      throw new BadRequestException(
+        'phaseIds must include every project phase exactly once',
+      );
+    }
+
+    const reorderedPhases = phaseIds.map((phaseId, index) => {
+      const phase = phasesById.get(phaseId) as ProjectPhase;
+      phase.orderIndex = index + 1;
+      return phase;
+    });
+
+    await this.projectPhasesRepository.save(reorderedPhases);
+
+    return reorderedPhases;
+  }
+
+  async deletePhase(projectId: number, phaseId: number): Promise<void> {
+    const phases = await this.findPhases(projectId);
+    const phase = phases.find((currentPhase) => currentPhase.id === phaseId);
+
+    if (!phase) {
+      throw new NotFoundException(
+        `Project phase with ID ${phaseId} not found in project ${projectId}`,
+      );
+    }
+
+    if (phases.length === 1) {
+      throw new BadRequestException('Projects must keep at least one phase');
+    }
+
+    await this.projectPhasesRepository.remove(phase);
+
+    const remainingPhases = phases
+      .filter((currentPhase) => currentPhase.id !== phaseId)
+      .map((currentPhase, index) => {
+        currentPhase.orderIndex = index + 1;
+        return currentPhase;
+      });
+
+    await this.projectPhasesRepository.save(remainingPhases);
+  }
+
   private validateDateRange(createProjectDto: CreateProjectDto): void {
     const { startDate, endDate } = createProjectDto;
 
@@ -68,5 +198,57 @@ export class ProjectsService {
         'startDate must be before or equal to endDate',
       );
     }
+  }
+
+  private createDefaultPhases(project: Project): Promise<ProjectPhase[]> {
+    const phases = DEFAULT_PROJECT_PHASES.map((name, index) =>
+      this.projectPhasesRepository.create({
+        name,
+        description: null,
+        orderIndex: index + 1,
+        projectId: project.id,
+        project,
+      }),
+    );
+
+    return this.projectPhasesRepository.save(phases);
+  }
+
+  private async ensureProjectExists(projectId: number): Promise<Project> {
+    const project = await this.projectsRepository.findOne({
+      where: { id: projectId },
+    });
+
+    if (!project) {
+      throw new NotFoundException(`Project with ID ${projectId} not found`);
+    }
+
+    return project;
+  }
+
+  private async findPhaseOrThrow(
+    projectId: number,
+    phaseId: number,
+  ): Promise<ProjectPhase> {
+    const phase = await this.projectPhasesRepository.findOne({
+      where: { id: phaseId, projectId },
+    });
+
+    if (!phase) {
+      throw new NotFoundException(
+        `Project phase with ID ${phaseId} not found in project ${projectId}`,
+      );
+    }
+
+    return phase;
+  }
+
+  private async getNextPhaseOrderIndex(projectId: number): Promise<number> {
+    const lastPhase = await this.projectPhasesRepository.findOne({
+      where: { projectId },
+      order: { orderIndex: 'DESC' },
+    });
+
+    return (lastPhase?.orderIndex ?? 0) + 1;
   }
 }


### PR DESCRIPTION
## Summary
This PR adds project phase structure management.
The goal is to give projects an internal ordered structure before task creation and future progress tracking are added.

## Related Issue / Requirement
- Issue: UNI2-20
- Requirement: project phase structure management

## What Changed
- Added a `ProjectPhase` entity linked to `Project`.
- Added default project phases created automatically for new projects.
- Added DTOs for creating, updating, and reordering project phases.
- Updated `ProjectsService` to list, create, update, reorder, and delete phases.
- Updated project detail retrieval to include ordered phases.
- Added project phase endpoints under `/projects/:projectId/phases`.
- Added unit tests for default phase creation, phase management, reordering, deletion rules, and controller wiring.

## How to Test
- Run `npm test` from `apps/backend`.
- Run `npm run type-check` from `apps/backend`.
- Run `npm run lint` from `apps/backend`.
- Verify that `POST /projects` creates default phases.
- Verify that `GET /projects/:id` returns project phases.
- Verify that `POST /projects/:projectId/phases` creates a custom phase.
- Verify that `PATCH /projects/:projectId/phases/:phaseId` updates a phase.
- Verify that `PATCH /projects/:projectId/phases/reorder` reorders all phases.
- Verify that `DELETE /projects/:projectId/phases/:phaseId` deletes a phase but rejects deleting the last remaining phase.

## Screenshots / Evidence
Local verification:
- `npm test`: 92 tests passed.
<img width="846" height="756" alt="image" src="https://github.com/user-attachments/assets/14a2c5c8-fa80-4cd0-a31c-e4ab279a8e47" />

- `npm run type-check`: OK.
<img width="717" height="246" alt="image" src="https://github.com/user-attachments/assets/a8987635-47ec-4bdd-977b-d10f049d811e" />

- `npm run lint`: OK.
<img width="725" height="247" alt="image" src="https://github.com/user-attachments/assets/05e02462-63c3-4d53-8ca5-0b934fa86a58" />


## Notes
Project permissions are still left as a TODO, matching the current project module, because access rules for project management are not defined yet.