### PR TITLE
Uni2 21 featprojects add project metadata links and filtering

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -29,7 +29,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.15.1",
+    "class-validator": "^0.14.4",
     "pg": "^8.20.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/apps/backend/src/projects/dto/create-project-link.dto.ts
+++ b/apps/backend/src/projects/dto/create-project-link.dto.ts
@@ -1,0 +1,18 @@
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString, IsUrl, MaxLength } from 'class-validator';
+
+const trimString = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+export class CreateProjectLinkDto {
+  @Transform(trimString)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @Transform(trimString)
+  @IsUrl({ require_protocol: true })
+  @MaxLength(2048)
+  url: string;
+}

--- a/apps/backend/src/projects/dto/create-project.dto.spec.ts
+++ b/apps/backend/src/projects/dto/create-project.dto.spec.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
+import { ProjectStatus } from '../enums/project-status.enum';
 import { CreateProjectDto } from './create-project.dto';
 
 const validProjectPayload = {
@@ -74,6 +75,65 @@ describe('CreateProjectDto', () => {
       expect.arrayContaining([
         expect.objectContaining({
           property: 'areaId',
+        }),
+      ]),
+    );
+  });
+
+  it('accepts and normalizes project metadata', async () => {
+    const dto = plainToInstance(CreateProjectDto, {
+      ...validProjectPayload,
+      status: ProjectStatus.ACTIVE,
+      labels: ['  Backend  ', 'Priority'],
+      links: [
+        {
+          name: '  Repository  ',
+          url: '  https://github.com/ccUnicode/UNICORE  ',
+        },
+      ],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.labels).toEqual(['Backend', 'Priority']);
+    expect(dto.links).toEqual([
+      {
+        name: 'Repository',
+        url: 'https://github.com/ccUnicode/UNICORE',
+      },
+    ]);
+  });
+
+  it('rejects duplicate labels regardless of casing', async () => {
+    const dto = plainToInstance(CreateProjectDto, {
+      ...validProjectPayload,
+      labels: ['Backend', 'backend'],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          property: 'labels',
+        }),
+      ]),
+    );
+  });
+
+  it('rejects external links without an absolute URL', async () => {
+    const dto = plainToInstance(CreateProjectDto, {
+      ...validProjectPayload,
+      links: [{ name: 'Repository', url: 'github.com/ccUnicode/UNICORE' }],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          property: 'links',
         }),
       ]),
     );

--- a/apps/backend/src/projects/dto/create-project.dto.ts
+++ b/apps/backend/src/projects/dto/create-project.dto.ts
@@ -1,16 +1,30 @@
 import { Transform, Type } from 'class-transformer';
 import {
+  ArrayMaxSize,
+  ArrayUnique,
+  IsArray,
   IsDateString,
+  IsEnum,
   IsInt,
   IsNotEmpty,
   IsOptional,
   IsString,
   MaxLength,
   Min,
+  ValidateNested,
 } from 'class-validator';
+import { ProjectStatus } from '../enums/project-status.enum';
+import { CreateProjectLinkDto } from './create-project-link.dto';
 
 const trimString = ({ value }: { value: unknown }) =>
   typeof value === 'string' ? value.trim() : value;
+
+const trimStringArray = ({ value }: { value: unknown }): unknown =>
+  Array.isArray(value)
+    ? (value as unknown[]).map((item) =>
+        typeof item === 'string' ? item.trim() : item,
+      )
+    : value;
 
 export class CreateProjectDto {
   @Transform(trimString)
@@ -37,4 +51,27 @@ export class CreateProjectDto {
   @IsInt()
   @Min(1)
   areaId: number;
+
+  @IsOptional()
+  @IsEnum(ProjectStatus)
+  status?: ProjectStatus;
+
+  @IsOptional()
+  @Transform(trimStringArray)
+  @IsArray()
+  @ArrayMaxSize(20)
+  @ArrayUnique((label: unknown) =>
+    typeof label === 'string' ? label.toLocaleLowerCase() : label,
+  )
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @MaxLength(50, { each: true })
+  labels?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(20)
+  @ValidateNested({ each: true })
+  @Type(() => CreateProjectLinkDto)
+  links?: CreateProjectLinkDto[];
 }

--- a/apps/backend/src/projects/dto/get-projects-filter.dto.spec.ts
+++ b/apps/backend/src/projects/dto/get-projects-filter.dto.spec.ts
@@ -1,0 +1,51 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ProjectStatus } from '../enums/project-status.enum';
+import { GetProjectsFilterDto } from './get-projects-filter.dto';
+
+describe('GetProjectsFilterDto', () => {
+  it('transforms query filters', async () => {
+    const dto = plainToInstance(GetProjectsFilterDto, {
+      page: '2',
+      limit: '25',
+      areaId: '4',
+      status: ProjectStatus.ACTIVE,
+      labels: ' Backend,Priority ',
+      search: '  portal  ',
+      archived: 'true',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-30',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto).toEqual(
+      expect.objectContaining({
+        page: 2,
+        limit: 25,
+        areaId: 4,
+        labels: ['Backend', 'Priority'],
+        search: 'portal',
+        archived: true,
+      }),
+    );
+  });
+
+  it('rejects invalid archived filters', async () => {
+    const dto = plainToInstance(GetProjectsFilterDto, {
+      archived: 'yes',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          property: 'archived',
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/backend/src/projects/dto/get-projects-filter.dto.ts
+++ b/apps/backend/src/projects/dto/get-projects-filter.dto.ts
@@ -1,0 +1,84 @@
+import { Transform, Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayUnique,
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+import { ProjectStatus } from '../enums/project-status.enum';
+
+const trimString = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+const toStringArray = ({ value }: { value: unknown }): unknown => {
+  const values = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(',')
+      : value;
+
+  return Array.isArray(values)
+    ? (values as unknown[]).map((item) =>
+        typeof item === 'string' ? item.trim() : item,
+      )
+    : values;
+};
+
+const toBoolean = ({ value }: { value: unknown }): unknown => {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return value;
+};
+
+export class GetProjectsFilterDto extends PaginationDto {
+  @IsOptional()
+  @IsEnum(ProjectStatus)
+  status?: ProjectStatus;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  areaId?: number;
+
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @IsOptional()
+  @Transform(toStringArray)
+  @IsArray()
+  @ArrayMaxSize(20)
+  @ArrayUnique((label: unknown) =>
+    typeof label === 'string' ? label.toLocaleLowerCase() : label,
+  )
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @MaxLength(50, { each: true })
+  labels?: string[];
+
+  @IsOptional()
+  @Transform(trimString)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  search?: string;
+
+  @IsOptional()
+  @Transform(toBoolean)
+  @IsBoolean()
+  archived?: boolean;
+}

--- a/apps/backend/src/projects/dto/update-project.dto.spec.ts
+++ b/apps/backend/src/projects/dto/update-project.dto.spec.ts
@@ -1,0 +1,70 @@
+import { ArgumentMetadata, ValidationPipe } from '@nestjs/common';
+import { ProjectStatus } from '../enums/project-status.enum';
+import { UpdateProjectDto } from './update-project.dto';
+
+const bodyMetadata: ArgumentMetadata = {
+  type: 'body',
+  metatype: UpdateProjectDto,
+};
+
+describe('UpdateProjectDto', () => {
+  const validationPipe = new ValidationPipe({
+    transform: true,
+    whitelist: true,
+  });
+
+  it('validates, transforms, and preserves partial project updates', async () => {
+    const result = (await validationPipe.transform(
+      {
+        name: '  Portal actualizado  ',
+        status: ProjectStatus.ACTIVE,
+        labels: ['  Backend  '],
+        links: [
+          {
+            name: '  Repository  ',
+            url: '  https://github.com/ccUnicode/UNICORE  ',
+          },
+        ],
+      },
+      bodyMetadata,
+    )) as unknown;
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        name: 'Portal actualizado',
+        status: ProjectStatus.ACTIVE,
+        labels: ['Backend'],
+        links: [
+          {
+            name: 'Repository',
+            url: 'https://github.com/ccUnicode/UNICORE',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('allows nullable fields to be cleared', async () => {
+    await expect(
+      validationPipe.transform(
+        { description: null, startDate: null, endDate: null },
+        bodyMetadata,
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        description: null,
+        startDate: null,
+        endDate: null,
+      }),
+    );
+  });
+
+  it.each(['name', 'areaId', 'status', 'labels', 'links'])(
+    'rejects null for %s',
+    async (property) => {
+      await expect(
+        validationPipe.transform({ [property]: null }, bodyMetadata),
+      ).rejects.toMatchObject({ status: 400 });
+    },
+  );
+});

--- a/apps/backend/src/projects/dto/update-project.dto.ts
+++ b/apps/backend/src/projects/dto/update-project.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateProjectDto } from './create-project.dto';
+
+export class UpdateProjectDto extends PartialType(CreateProjectDto) {}

--- a/apps/backend/src/projects/dto/update-project.dto.ts
+++ b/apps/backend/src/projects/dto/update-project.dto.ts
@@ -1,4 +1,83 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateProjectDto } from './create-project.dto';
+import { Transform, Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayUnique,
+  IsArray,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+import { ProjectStatus } from '../enums/project-status.enum';
+import { CreateProjectLinkDto } from './create-project-link.dto';
 
-export class UpdateProjectDto extends PartialType(CreateProjectDto) {}
+const isDefined = (_object: unknown, value: unknown) => value !== undefined;
+const isDefinedAndNotNull = (_object: unknown, value: unknown) =>
+  value !== undefined && value !== null;
+
+const trimString = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+const trimStringArray = ({ value }: { value: unknown }): unknown =>
+  Array.isArray(value)
+    ? (value as unknown[]).map((item) =>
+        typeof item === 'string' ? item.trim() : item,
+      )
+    : value;
+
+export class UpdateProjectDto {
+  @ValidateIf(isDefined)
+  @Transform(trimString)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  name?: string;
+
+  @ValidateIf(isDefinedAndNotNull)
+  @Transform(trimString)
+  @IsString()
+  @MaxLength(2000)
+  description?: string | null;
+
+  @ValidateIf(isDefinedAndNotNull)
+  @IsDateString()
+  startDate?: string | null;
+
+  @ValidateIf(isDefinedAndNotNull)
+  @IsDateString()
+  endDate?: string | null;
+
+  @ValidateIf(isDefined)
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  areaId?: number;
+
+  @ValidateIf(isDefined)
+  @IsEnum(ProjectStatus)
+  status?: ProjectStatus;
+
+  @ValidateIf(isDefined)
+  @Transform(trimStringArray)
+  @IsArray()
+  @ArrayMaxSize(20)
+  @ArrayUnique((label: unknown) =>
+    typeof label === 'string' ? label.toLocaleLowerCase() : label,
+  )
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @MaxLength(50, { each: true })
+  labels?: string[];
+
+  @ValidateIf(isDefined)
+  @IsArray()
+  @ArrayMaxSize(20)
+  @ValidateNested({ each: true })
+  @Type(() => CreateProjectLinkDto)
+  links?: CreateProjectLinkDto[];
+}

--- a/apps/backend/src/projects/entities/project-label.entity.ts
+++ b/apps/backend/src/projects/entities/project-label.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+
+@Entity('project_labels')
+export class ProjectLabel {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'varchar', length: 50 })
+  name: string;
+
+  @Column({
+    name: 'normalized_name',
+    type: 'varchar',
+    length: 50,
+    unique: true,
+  })
+  normalizedName: string;
+
+  @ManyToMany(() => Project, (project) => project.labels)
+  projects: Project[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/apps/backend/src/projects/entities/project-link.entity.ts
+++ b/apps/backend/src/projects/entities/project-link.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+
+@Entity('project_links')
+export class ProjectLink {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'varchar', length: 100 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 2048 })
+  url: string;
+
+  @Column({ name: 'project_id', type: 'int' })
+  projectId: number;
+
+  @ManyToOne(() => Project, (project) => project.links, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'project_id' })
+  project: Project;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/apps/backend/src/projects/entities/project.entity.ts
+++ b/apps/backend/src/projects/entities/project.entity.ts
@@ -2,6 +2,8 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinTable,
+  ManyToMany,
   JoinColumn,
   ManyToOne,
   OneToMany,
@@ -9,6 +11,9 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { Area } from '../../area/entities/area.entity';
+import { ProjectStatus } from '../enums/project-status.enum';
+import { ProjectLabel } from './project-label.entity';
+import { ProjectLink } from './project-link.entity';
 import { ProjectPhase } from './project-phase.entity';
 
 @Entity('projects')
@@ -31,12 +36,29 @@ export class Project {
   @Column({ name: 'area_id', type: 'int' })
   areaId: number;
 
+  @Column({ type: 'enum', enum: ProjectStatus, default: ProjectStatus.PLANNED })
+  status: ProjectStatus;
+
+  @Column({ name: 'is_archived', type: 'boolean', default: false })
+  isArchived: boolean;
+
   @ManyToOne(() => Area, { onDelete: 'RESTRICT', nullable: false })
   @JoinColumn({ name: 'area_id' })
   area: Area;
 
   @OneToMany(() => ProjectPhase, (phase) => phase.project)
   phases: ProjectPhase[];
+
+  @ManyToMany(() => ProjectLabel, (label) => label.projects)
+  @JoinTable({
+    name: 'project_label_assignments',
+    joinColumn: { name: 'project_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'label_id', referencedColumnName: 'id' },
+  })
+  labels: ProjectLabel[];
+
+  @OneToMany(() => ProjectLink, (link) => link.project)
+  links: ProjectLink[];
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/apps/backend/src/projects/enums/project-status.enum.ts
+++ b/apps/backend/src/projects/enums/project-status.enum.ts
@@ -1,0 +1,7 @@
+export enum ProjectStatus {
+  PLANNED = 'planned',
+  ACTIVE = 'active',
+  ON_HOLD = 'on_hold',
+  COMPLETED = 'completed',
+  CANCELLED = 'cancelled',
+}

--- a/apps/backend/src/projects/projects.controller.spec.ts
+++ b/apps/backend/src/projects/projects.controller.spec.ts
@@ -196,15 +196,58 @@ describe('ProjectsController', () => {
       expect(guards).toContain(RolesGuard);
     });
 
-    it('restricts project updates and archiving to Presidencia and Directiva', () => {
-      const expectedRoles = [AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA];
+    it.each([
+      'create',
+      'update',
+      'archive',
+      'createPhase',
+      'reorderPhases',
+      'updatePhase',
+      'deletePhase',
+    ] as const)('restricts %s to Presidencia and Directiva', (methodName) => {
+      expect(
+        Reflect.getMetadata(ROLES_KEY, getProjectsControllerMethod(methodName)),
+      ).toEqual([AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA]);
+    });
 
-      expect(
-        Reflect.getMetadata(ROLES_KEY, getProjectsControllerMethod('update')),
-      ).toEqual(expectedRoles);
-      expect(
-        Reflect.getMetadata(ROLES_KEY, getProjectsControllerMethod('archive')),
-      ).toEqual(expectedRoles);
+    it.each(['findAll', 'findOne', 'findPhases'] as const)(
+      'allows scoped read access to %s',
+      (methodName) => {
+        expect(
+          Reflect.getMetadata(
+            ROLES_KEY,
+            getProjectsControllerMethod(methodName),
+          ),
+        ).toEqual([
+          AreaRole.PRESIDENCIA,
+          AreaRole.DIRECTIVA_DE_AREA,
+          AreaRole.MIEMBRO,
+        ]);
+      },
+    );
+
+    it('declares roles for every controller route', () => {
+      const routeMethods = [
+        'create',
+        'findAll',
+        'findOne',
+        'update',
+        'archive',
+        'findPhases',
+        'createPhase',
+        'reorderPhases',
+        'updatePhase',
+        'deletePhase',
+      ] as const;
+
+      routeMethods.forEach((methodName) => {
+        expect(
+          Reflect.getMetadata(
+            ROLES_KEY,
+            getProjectsControllerMethod(methodName),
+          ),
+        ).toBeDefined();
+      });
     });
   });
 

--- a/apps/backend/src/projects/projects.controller.spec.ts
+++ b/apps/backend/src/projects/projects.controller.spec.ts
@@ -1,6 +1,9 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Area } from '../area/entities/area.entity';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
 import { AreaRole } from '../common/enums/area-role.enum';
+import { RolesGuard } from '../common/guards/roles.guard';
 import { CreateProjectPhaseDto } from './dto/create-project-phase.dto';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { ReorderProjectPhasesDto } from './dto/reorder-project-phases.dto';
@@ -10,6 +13,19 @@ import { Project } from './entities/project.entity';
 import { ProjectStatus } from './enums/project-status.enum';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
+
+const getProjectsControllerMethod = (methodName: keyof ProjectsController) => {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    ProjectsController.prototype,
+    methodName,
+  );
+
+  if (!descriptor) {
+    throw new Error(`Missing ProjectsController method: ${String(methodName)}`);
+  }
+
+  return descriptor.value as object;
+};
 
 const createArea = (overrides: Partial<Area> = {}): Area => ({
   id: 1,
@@ -168,6 +184,28 @@ describe('ProjectsController', () => {
 
     await expect(controller.archive(1)).resolves.toEqual(project);
     expect(mockProjectsService.archive).toHaveBeenCalledWith(1);
+  });
+
+  describe('access metadata', () => {
+    it('uses RolesGuard at controller level', () => {
+      const guards = Reflect.getMetadata(
+        GUARDS_METADATA,
+        ProjectsController,
+      ) as Array<new (...args: unknown[]) => unknown>;
+
+      expect(guards).toContain(RolesGuard);
+    });
+
+    it('restricts project updates and archiving to Presidencia and Directiva', () => {
+      const expectedRoles = [AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA];
+
+      expect(
+        Reflect.getMetadata(ROLES_KEY, getProjectsControllerMethod('update')),
+      ).toEqual(expectedRoles);
+      expect(
+        Reflect.getMetadata(ROLES_KEY, getProjectsControllerMethod('archive')),
+      ).toEqual(expectedRoles);
+    });
   });
 
   it('lists project phases through the service', async () => {

--- a/apps/backend/src/projects/projects.controller.spec.ts
+++ b/apps/backend/src/projects/projects.controller.spec.ts
@@ -74,6 +74,8 @@ const createProject = (overrides: Partial<Project> = {}): Project => {
   };
 };
 
+const presidencyActor = { role: AreaRole.PRESIDENCIA };
+
 describe('ProjectsController', () => {
   let controller: ProjectsController;
 
@@ -118,10 +120,13 @@ describe('ProjectsController', () => {
 
     mockProjectsService.create.mockResolvedValue(createdProject);
 
-    await expect(controller.create(createProjectDto)).resolves.toEqual(
-      createdProject,
+    await expect(
+      controller.create(createProjectDto, presidencyActor),
+    ).resolves.toEqual(createdProject);
+    expect(mockProjectsService.create).toHaveBeenCalledWith(
+      createProjectDto,
+      presidencyActor,
     );
-    expect(mockProjectsService.create).toHaveBeenCalledWith(createProjectDto);
   });
 
   it('lists projects through the service with pagination', async () => {
@@ -153,8 +158,13 @@ describe('ProjectsController', () => {
 
     mockProjectsService.findOne.mockResolvedValue(project);
 
-    await expect(controller.findOne(1)).resolves.toEqual(project);
-    expect(mockProjectsService.findOne).toHaveBeenCalledWith(1);
+    await expect(controller.findOne(1, presidencyActor)).resolves.toEqual(
+      project,
+    );
+    expect(mockProjectsService.findOne).toHaveBeenCalledWith(
+      1,
+      presidencyActor,
+    );
   });
 
   it('updates projects through the service', async () => {
@@ -168,12 +178,13 @@ describe('ProjectsController', () => {
 
     mockProjectsService.update.mockResolvedValue(project);
 
-    await expect(controller.update(1, updateProjectDto)).resolves.toEqual(
-      project,
-    );
+    await expect(
+      controller.update(1, updateProjectDto, presidencyActor),
+    ).resolves.toEqual(project);
     expect(mockProjectsService.update).toHaveBeenCalledWith(
       1,
       updateProjectDto,
+      presidencyActor,
     );
   });
 
@@ -182,8 +193,13 @@ describe('ProjectsController', () => {
 
     mockProjectsService.archive.mockResolvedValue(project);
 
-    await expect(controller.archive(1)).resolves.toEqual(project);
-    expect(mockProjectsService.archive).toHaveBeenCalledWith(1);
+    await expect(controller.archive(1, presidencyActor)).resolves.toEqual(
+      project,
+    );
+    expect(mockProjectsService.archive).toHaveBeenCalledWith(
+      1,
+      presidencyActor,
+    );
   });
 
   describe('access metadata', () => {
@@ -256,8 +272,13 @@ describe('ProjectsController', () => {
 
     mockProjectsService.findPhases.mockResolvedValue(phases);
 
-    await expect(controller.findPhases(1)).resolves.toEqual(phases);
-    expect(mockProjectsService.findPhases).toHaveBeenCalledWith(1);
+    await expect(controller.findPhases(1, presidencyActor)).resolves.toEqual(
+      phases,
+    );
+    expect(mockProjectsService.findPhases).toHaveBeenCalledWith(
+      1,
+      presidencyActor,
+    );
   });
 
   it('creates project phases through the service', async () => {
@@ -273,11 +294,12 @@ describe('ProjectsController', () => {
     mockProjectsService.createPhase.mockResolvedValue(phase);
 
     await expect(
-      controller.createPhase(1, createProjectPhaseDto),
+      controller.createPhase(1, createProjectPhaseDto, presidencyActor),
     ).resolves.toEqual(phase);
     expect(mockProjectsService.createPhase).toHaveBeenCalledWith(
       1,
       createProjectPhaseDto,
+      presidencyActor,
     );
   });
 
@@ -290,12 +312,13 @@ describe('ProjectsController', () => {
     mockProjectsService.updatePhase.mockResolvedValue(phase);
 
     await expect(
-      controller.updatePhase(1, 2, updateProjectPhaseDto),
+      controller.updatePhase(1, 2, updateProjectPhaseDto, presidencyActor),
     ).resolves.toEqual(phase);
     expect(mockProjectsService.updatePhase).toHaveBeenCalledWith(
       1,
       2,
       updateProjectPhaseDto,
+      presidencyActor,
     );
   });
 
@@ -311,18 +334,25 @@ describe('ProjectsController', () => {
     mockProjectsService.reorderPhases.mockResolvedValue(phases);
 
     await expect(
-      controller.reorderPhases(1, reorderProjectPhasesDto),
+      controller.reorderPhases(1, reorderProjectPhasesDto, presidencyActor),
     ).resolves.toEqual(phases);
     expect(mockProjectsService.reorderPhases).toHaveBeenCalledWith(
       1,
       reorderProjectPhasesDto,
+      presidencyActor,
     );
   });
 
   it('deletes project phases through the service', async () => {
     mockProjectsService.deletePhase.mockResolvedValue(undefined);
 
-    await expect(controller.deletePhase(1, 2)).resolves.toBeUndefined();
-    expect(mockProjectsService.deletePhase).toHaveBeenCalledWith(1, 2);
+    await expect(
+      controller.deletePhase(1, 2, presidencyActor),
+    ).resolves.toBeUndefined();
+    expect(mockProjectsService.deletePhase).toHaveBeenCalledWith(
+      1,
+      2,
+      presidencyActor,
+    );
   });
 });

--- a/apps/backend/src/projects/projects.controller.spec.ts
+++ b/apps/backend/src/projects/projects.controller.spec.ts
@@ -1,11 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Area } from '../area/entities/area.entity';
+import { AreaRole } from '../common/enums/area-role.enum';
 import { CreateProjectPhaseDto } from './dto/create-project-phase.dto';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { ReorderProjectPhasesDto } from './dto/reorder-project-phases.dto';
 import { UpdateProjectPhaseDto } from './dto/update-project-phase.dto';
 import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
+import { ProjectStatus } from './enums/project-status.enum';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 
@@ -45,7 +47,11 @@ const createProject = (overrides: Partial<Project> = {}): Project => {
     endDate: '2026-07-01',
     areaId: area.id,
     area,
+    status: ProjectStatus.PLANNED,
+    isArchived: false,
     phases: [],
+    labels: [],
+    links: [],
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -59,6 +65,8 @@ describe('ProjectsController', () => {
     create: jest.fn(),
     findAll: jest.fn(),
     findOne: jest.fn(),
+    update: jest.fn(),
+    archive: jest.fn(),
     findPhases: jest.fn(),
     createPhase: jest.fn(),
     updatePhase: jest.fn(),
@@ -102,6 +110,7 @@ describe('ProjectsController', () => {
 
   it('lists projects through the service with pagination', async () => {
     const paginationDto = { page: 2, limit: 5 };
+    const accessActor = { role: AreaRole.PRESIDENCIA };
     const response = {
       data: [createProject()],
       meta: {
@@ -114,8 +123,13 @@ describe('ProjectsController', () => {
 
     mockProjectsService.findAll.mockResolvedValue(response);
 
-    await expect(controller.findAll(paginationDto)).resolves.toEqual(response);
-    expect(mockProjectsService.findAll).toHaveBeenCalledWith(paginationDto);
+    await expect(
+      controller.findAll(accessActor, paginationDto),
+    ).resolves.toEqual(response);
+    expect(mockProjectsService.findAll).toHaveBeenCalledWith(
+      paginationDto,
+      accessActor,
+    );
   });
 
   it('gets project detail through the service', async () => {
@@ -125,6 +139,35 @@ describe('ProjectsController', () => {
 
     await expect(controller.findOne(1)).resolves.toEqual(project);
     expect(mockProjectsService.findOne).toHaveBeenCalledWith(1);
+  });
+
+  it('updates projects through the service', async () => {
+    const updateProjectDto = {
+      status: ProjectStatus.ACTIVE,
+      labels: ['Backend'],
+    };
+    const project = createProject({
+      status: ProjectStatus.ACTIVE,
+    });
+
+    mockProjectsService.update.mockResolvedValue(project);
+
+    await expect(controller.update(1, updateProjectDto)).resolves.toEqual(
+      project,
+    );
+    expect(mockProjectsService.update).toHaveBeenCalledWith(
+      1,
+      updateProjectDto,
+    );
+  });
+
+  it('archives projects through the service', async () => {
+    const project = createProject({ isArchived: true });
+
+    mockProjectsService.archive.mockResolvedValue(project);
+
+    await expect(controller.archive(1)).resolves.toEqual(project);
+    expect(mockProjectsService.archive).toHaveBeenCalledWith(1);
   });
 
   it('lists project phases through the service', async () => {

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -48,6 +48,7 @@ export class ProjectsController {
   }
 
   @Patch(':id')
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateProjectDto: UpdateProjectDto,
@@ -56,6 +57,7 @@ export class ProjectsController {
   }
 
   @Patch(':id/archive')
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
   archive(@Param('id', ParseIntPipe) id: number) {
     return this.projectsService.archive(id);
   }

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -29,6 +29,7 @@ export class ProjectsController {
   constructor(private readonly projectsService: ProjectsService) {}
 
   @Post()
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
   create(@Body() createProjectDto: CreateProjectDto) {
     return this.projectsService.create(createProjectDto);
   }
@@ -43,6 +44,7 @@ export class ProjectsController {
   }
 
   @Get(':id')
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA, AreaRole.MIEMBRO)
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.projectsService.findOne(id);
   }
@@ -63,11 +65,13 @@ export class ProjectsController {
   }
 
   @Get(':projectId/phases')
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA, AreaRole.MIEMBRO)
   findPhases(@Param('projectId', ParseIntPipe) projectId: number) {
     return this.projectsService.findPhases(projectId);
   }
 
   @Post(':projectId/phases')
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
   createPhase(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Body() createProjectPhaseDto: CreateProjectPhaseDto,
@@ -76,6 +80,7 @@ export class ProjectsController {
   }
 
   @Patch(':projectId/phases/reorder')
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
   reorderPhases(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Body() reorderProjectPhasesDto: ReorderProjectPhasesDto,
@@ -87,6 +92,7 @@ export class ProjectsController {
   }
 
   @Patch(':projectId/phases/:phaseId')
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
   updatePhase(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Param('phaseId', ParseIntPipe) phaseId: number,
@@ -100,6 +106,7 @@ export class ProjectsController {
   }
 
   @Delete(':projectId/phases/:phaseId')
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
   deletePhase(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Param('phaseId', ParseIntPipe) phaseId: number,

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -30,8 +30,11 @@ export class ProjectsController {
 
   @Post()
   @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
-  create(@Body() createProjectDto: CreateProjectDto) {
-    return this.projectsService.create(createProjectDto);
+  create(
+    @Body() createProjectDto: CreateProjectDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.projectsService.create(createProjectDto, accessActor);
   }
 
   @Get()
@@ -45,8 +48,11 @@ export class ProjectsController {
 
   @Get(':id')
   @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA, AreaRole.MIEMBRO)
-  findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.projectsService.findOne(id);
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.projectsService.findOne(id, accessActor);
   }
 
   @Patch(':id')
@@ -54,20 +60,27 @@ export class ProjectsController {
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateProjectDto: UpdateProjectDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ) {
-    return this.projectsService.update(id, updateProjectDto);
+    return this.projectsService.update(id, updateProjectDto, accessActor);
   }
 
   @Patch(':id/archive')
   @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
-  archive(@Param('id', ParseIntPipe) id: number) {
-    return this.projectsService.archive(id);
+  archive(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.projectsService.archive(id, accessActor);
   }
 
   @Get(':projectId/phases')
   @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA, AreaRole.MIEMBRO)
-  findPhases(@Param('projectId', ParseIntPipe) projectId: number) {
-    return this.projectsService.findPhases(projectId);
+  findPhases(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.projectsService.findPhases(projectId, accessActor);
   }
 
   @Post(':projectId/phases')
@@ -75,8 +88,13 @@ export class ProjectsController {
   createPhase(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Body() createProjectPhaseDto: CreateProjectPhaseDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ) {
-    return this.projectsService.createPhase(projectId, createProjectPhaseDto);
+    return this.projectsService.createPhase(
+      projectId,
+      createProjectPhaseDto,
+      accessActor,
+    );
   }
 
   @Patch(':projectId/phases/reorder')
@@ -84,10 +102,12 @@ export class ProjectsController {
   reorderPhases(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Body() reorderProjectPhasesDto: ReorderProjectPhasesDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ) {
     return this.projectsService.reorderPhases(
       projectId,
       reorderProjectPhasesDto,
+      accessActor,
     );
   }
 
@@ -97,11 +117,13 @@ export class ProjectsController {
     @Param('projectId', ParseIntPipe) projectId: number,
     @Param('phaseId', ParseIntPipe) phaseId: number,
     @Body() updateProjectPhaseDto: UpdateProjectPhaseDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ) {
     return this.projectsService.updatePhase(
       projectId,
       phaseId,
       updateProjectPhaseDto,
+      accessActor,
     );
   }
 
@@ -110,7 +132,8 @@ export class ProjectsController {
   deletePhase(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Param('phaseId', ParseIntPipe) phaseId: number,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ) {
-    return this.projectsService.deletePhase(projectId, phaseId);
+    return this.projectsService.deletePhase(projectId, phaseId, accessActor);
   }
 }

--- a/apps/backend/src/projects/projects.controller.ts
+++ b/apps/backend/src/projects/projects.controller.ts
@@ -8,16 +8,23 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
-import { PaginationDto } from '../common/dto/pagination.dto';
+import { CurrentAccessActor } from '../common/decorators/current-access-actor.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { RolesGuard } from '../common/guards/roles.guard';
+import type { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { CreateProjectPhaseDto } from './dto/create-project-phase.dto';
 import { CreateProjectDto } from './dto/create-project.dto';
+import { GetProjectsFilterDto } from './dto/get-projects-filter.dto';
 import { ReorderProjectPhasesDto } from './dto/reorder-project-phases.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
 import { UpdateProjectPhaseDto } from './dto/update-project-phase.dto';
 import { ProjectsService } from './projects.service';
 
-// TODO: Add project permissions once the access rules are defined.
 @Controller('projects')
+@UseGuards(RolesGuard)
 export class ProjectsController {
   constructor(private readonly projectsService: ProjectsService) {}
 
@@ -27,13 +34,30 @@ export class ProjectsController {
   }
 
   @Get()
-  findAll(@Query() paginationDto: PaginationDto) {
-    return this.projectsService.findAll(paginationDto);
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA, AreaRole.MIEMBRO)
+  findAll(
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+    @Query() filterDto: GetProjectsFilterDto,
+  ) {
+    return this.projectsService.findAll(filterDto, accessActor);
   }
 
   @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.projectsService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateProjectDto: UpdateProjectDto,
+  ) {
+    return this.projectsService.update(id, updateProjectDto);
+  }
+
+  @Patch(':id/archive')
+  archive(@Param('id', ParseIntPipe) id: number) {
+    return this.projectsService.archive(id);
   }
 
   @Get(':projectId/phases')

--- a/apps/backend/src/projects/projects.module.ts
+++ b/apps/backend/src/projects/projects.module.ts
@@ -1,13 +1,23 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AreaModule } from '../area/area.module';
+import { ProjectLabel } from './entities/project-label.entity';
+import { ProjectLink } from './entities/project-link.entity';
 import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 
 @Module({
-  imports: [AreaModule, TypeOrmModule.forFeature([Project, ProjectPhase])],
+  imports: [
+    AreaModule,
+    TypeOrmModule.forFeature([
+      Project,
+      ProjectPhase,
+      ProjectLabel,
+      ProjectLink,
+    ]),
+  ],
   controllers: [ProjectsController],
   providers: [ProjectsService],
   exports: [ProjectsService],

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -683,6 +683,36 @@ describe('ProjectsService', () => {
     );
   });
 
+  it('validates date updates using cleared nullable boundaries', async () => {
+    const project = createProject({
+      startDate: '2026-07-01',
+      endDate: '2026-08-01',
+    });
+    const updatedProject = createProject({
+      startDate: null,
+      endDate: '2026-06-01',
+    });
+
+    projectsRepository.findOne
+      ?.mockResolvedValueOnce(project)
+      .mockResolvedValueOnce(updatedProject);
+    projectsRepository.save?.mockResolvedValue(project);
+
+    await expect(
+      service.update(
+        1,
+        { startDate: null, endDate: '2026-06-01' },
+        presidencyActor,
+      ),
+    ).resolves.toEqual(updatedProject);
+    expect(projectsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: null,
+        endDate: '2026-06-01',
+      }),
+    );
+  });
+
   it('archives projects', async () => {
     const project = createProject();
     const archivedProject = createProject({ isArchived: true });

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import {
@@ -12,6 +16,7 @@ import {
 import { AreaService } from '../area/area.service';
 import { Area } from '../area/entities/area.entity';
 import { AreaRole } from '../common/enums/area-role.enum';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { DEFAULT_PROJECT_PHASES } from './constants/default-project-phases.constant';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { ProjectLabel } from './entities/project-label.entity';
@@ -107,6 +112,18 @@ const createProject = (overrides: Partial<Project> = {}): Project => {
     updatedAt: new Date(),
     ...overrides,
   };
+};
+
+const presidencyActor: RequestAccessActor = {
+  role: AreaRole.PRESIDENCIA,
+};
+const areaLeaderActor: RequestAccessActor = {
+  role: AreaRole.DIRECTIVA_DE_AREA,
+  areaId: '1',
+};
+const memberActor: RequestAccessActor = {
+  role: AreaRole.MIEMBRO,
+  projectIds: ['1'],
 };
 
 describe('ProjectsService', () => {
@@ -230,7 +247,9 @@ describe('ProjectsService', () => {
     projectsRepository.save?.mockResolvedValue(project);
     projectPhasesRepository.save?.mockResolvedValue(phases);
 
-    await expect(service.create(createProjectDto)).resolves.toEqual({
+    await expect(
+      service.create(createProjectDto, presidencyActor),
+    ).resolves.toEqual({
       ...project,
       phases,
     });
@@ -303,10 +322,13 @@ describe('ProjectsService', () => {
     projectPhasesRepository.save?.mockResolvedValue(phases);
 
     await expect(
-      service.create({
-        name: 'Proyecto sin fechas',
-        areaId: 1,
-      }),
+      service.create(
+        {
+          name: 'Proyecto sin fechas',
+          areaId: 1,
+        },
+        presidencyActor,
+      ),
     ).resolves.toEqual({
       ...project,
       phases,
@@ -348,17 +370,20 @@ describe('ProjectsService', () => {
     projectLinksRepository.save?.mockResolvedValue([link]);
 
     await expect(
-      service.create({
-        ...createProjectDto,
-        status: ProjectStatus.ACTIVE,
-        labels: ['Backend', 'Priority'],
-        links: [
-          {
-            name: 'Repository',
-            url: 'https://github.com/ccUnicode/UNICORE',
-          },
-        ],
-      }),
+      service.create(
+        {
+          ...createProjectDto,
+          status: ProjectStatus.ACTIVE,
+          labels: ['Backend', 'Priority'],
+          links: [
+            {
+              name: 'Repository',
+              url: 'https://github.com/ccUnicode/UNICORE',
+            },
+          ],
+        },
+        presidencyActor,
+      ),
     ).resolves.toEqual({
       ...project,
       phases: [],
@@ -384,10 +409,13 @@ describe('ProjectsService', () => {
     );
 
     await expect(
-      service.create({
-        ...createProjectDto,
-        areaId: 99,
-      }),
+      service.create(
+        {
+          ...createProjectDto,
+          areaId: 99,
+        },
+        presidencyActor,
+      ),
     ).rejects.toBeInstanceOf(NotFoundException);
     expect(projectsRepository.create).not.toHaveBeenCalled();
     expect(projectsRepository.save).not.toHaveBeenCalled();
@@ -396,13 +424,31 @@ describe('ProjectsService', () => {
 
   it('rejects projects with an end date before the start date', async () => {
     await expect(
-      service.create({
-        ...createProjectDto,
-        startDate: '2026-07-01',
-        endDate: '2026-06-01',
-      }),
+      service.create(
+        {
+          ...createProjectDto,
+          startDate: '2026-07-01',
+          endDate: '2026-06-01',
+        },
+        presidencyActor,
+      ),
     ).rejects.toThrow(
       new BadRequestException('startDate must be before or equal to endDate'),
+    );
+    expect(mockAreaService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('rejects project creation outside an area leader own area', async () => {
+    await expect(
+      service.create(
+        {
+          ...createProjectDto,
+          areaId: 2,
+        },
+        areaLeaderActor,
+      ),
+    ).rejects.toThrow(
+      new ForbiddenException('Project management is limited to your own area'),
     );
     expect(mockAreaService.findOne).not.toHaveBeenCalled();
   });
@@ -534,7 +580,7 @@ describe('ProjectsService', () => {
 
     projectsRepository.findOne?.mockResolvedValue(project);
 
-    await expect(service.findOne(1)).resolves.toEqual(project);
+    await expect(service.findOne(1, presidencyActor)).resolves.toEqual(project);
     expect(projectsRepository.findOne).toHaveBeenCalledWith({
       where: { id: 1 },
       relations: ['area', 'phases', 'labels', 'links'],
@@ -549,8 +595,26 @@ describe('ProjectsService', () => {
   it('rejects project detail when the project does not exist', async () => {
     projectsRepository.findOne?.mockResolvedValue(null);
 
-    await expect(service.findOne(99)).rejects.toThrow(
+    await expect(service.findOne(99, presidencyActor)).rejects.toThrow(
       new NotFoundException('Project with ID 99 not found'),
+    );
+  });
+
+  it('rejects project detail outside an area leader own area', async () => {
+    projectsRepository.findOne?.mockResolvedValue(
+      createProject({ areaId: 2, area: createArea({ id: 2 }) }),
+    );
+
+    await expect(service.findOne(1, areaLeaderActor)).rejects.toThrow(
+      new ForbiddenException('Project management is limited to your own area'),
+    );
+  });
+
+  it('rejects project detail for members without project assignment', async () => {
+    projectsRepository.findOne?.mockResolvedValue(createProject({ id: 2 }));
+
+    await expect(service.findOne(2, memberActor)).rejects.toThrow(
+      new ForbiddenException('Project access is limited to assigned projects'),
     );
   });
 
@@ -580,12 +644,16 @@ describe('ProjectsService', () => {
     projectLinksRepository.save?.mockResolvedValue([link]);
 
     await expect(
-      service.update(1, {
-        name: 'Portal actualizado',
-        status: ProjectStatus.ACTIVE,
-        labels: ['Frontend'],
-        links: [{ name: 'Design', url: 'https://figma.com/file/123' }],
-      }),
+      service.update(
+        1,
+        {
+          name: 'Portal actualizado',
+          status: ProjectStatus.ACTIVE,
+          labels: ['Frontend'],
+          links: [{ name: 'Design', url: 'https://figma.com/file/123' }],
+        },
+        presidencyActor,
+      ),
     ).resolves.toEqual(updatedProject);
     expect(projectLinksRepository.delete).toHaveBeenCalledWith({
       projectId: 1,
@@ -606,10 +674,42 @@ describe('ProjectsService', () => {
     projectsRepository.findOne?.mockResolvedValue(project);
     projectsRepository.save?.mockResolvedValue(archivedProject);
 
-    await expect(service.archive(1)).resolves.toEqual(archivedProject);
+    await expect(service.archive(1, presidencyActor)).resolves.toEqual(
+      archivedProject,
+    );
     expect(projectsRepository.save).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1, isArchived: true }),
     );
+  });
+
+  it('rejects updates and archiving outside an area leader own area', async () => {
+    const project = createProject({
+      areaId: 2,
+      area: createArea({ id: 2 }),
+    });
+    projectsRepository.findOne?.mockResolvedValue(project);
+
+    await expect(
+      service.update(1, { name: 'Sin permiso' }, areaLeaderActor),
+    ).rejects.toThrow(
+      new ForbiddenException('Project management is limited to your own area'),
+    );
+    await expect(service.archive(1, areaLeaderActor)).rejects.toThrow(
+      new ForbiddenException('Project management is limited to your own area'),
+    );
+    expect(projectsRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects moving a project outside an area leader own area', async () => {
+    projectsRepository.findOne?.mockResolvedValue(createProject());
+
+    await expect(
+      service.update(1, { areaId: 2 }, areaLeaderActor),
+    ).rejects.toThrow(
+      new ForbiddenException('Project management is limited to your own area'),
+    );
+    expect(mockAreaService.findOne).not.toHaveBeenCalled();
+    expect(projectsRepository.save).not.toHaveBeenCalled();
   });
 
   it('lists phases for an existing project', async () => {
@@ -619,11 +719,22 @@ describe('ProjectsService', () => {
     projectsRepository.findOne?.mockResolvedValue(project);
     projectPhasesRepository.find?.mockResolvedValue(phases);
 
-    await expect(service.findPhases(1)).resolves.toEqual(phases);
+    await expect(service.findPhases(1, presidencyActor)).resolves.toEqual(
+      phases,
+    );
     expect(projectPhasesRepository.find).toHaveBeenCalledWith({
       where: { projectId: 1 },
       order: { orderIndex: 'ASC' },
     });
+  });
+
+  it('rejects phase reads for members without project assignment', async () => {
+    projectsRepository.findOne?.mockResolvedValue(createProject({ id: 2 }));
+
+    await expect(service.findPhases(2, memberActor)).rejects.toThrow(
+      new ForbiddenException('Project access is limited to assigned projects'),
+    );
+    expect(projectPhasesRepository.find).not.toHaveBeenCalled();
   });
 
   it('creates custom phases after the current last phase', async () => {
@@ -642,10 +753,14 @@ describe('ProjectsService', () => {
     projectPhasesRepository.save?.mockResolvedValue(phase);
 
     await expect(
-      service.createPhase(1, {
-        name: 'Retrospective',
-        description: 'Closeout notes',
-      }),
+      service.createPhase(
+        1,
+        {
+          name: 'Retrospective',
+          description: 'Closeout notes',
+        },
+        presidencyActor,
+      ),
     ).resolves.toEqual(phase);
     expect(projectPhasesRepository.manager.transaction).toHaveBeenCalledTimes(
       1,
@@ -666,7 +781,21 @@ describe('ProjectsService', () => {
     });
   });
 
+  it('rejects phase creation outside an area leader own area', async () => {
+    projectsRepository.findOne?.mockResolvedValue(
+      createProject({ areaId: 2, area: createArea({ id: 2 }) }),
+    );
+
+    await expect(
+      service.createPhase(1, { name: 'Sin permiso' }, areaLeaderActor),
+    ).rejects.toThrow(
+      new ForbiddenException('Project management is limited to your own area'),
+    );
+    expect(projectPhasesRepository.save).not.toHaveBeenCalled();
+  });
+
   it('updates phase names and descriptions', async () => {
+    projectsRepository.findOne?.mockResolvedValue(createProject());
     const phase = createProjectPhase();
     const updatedPhase = createProjectPhase({
       name: 'Discovery',
@@ -679,10 +808,15 @@ describe('ProjectsService', () => {
     projectPhasesRepository.update?.mockResolvedValue({ affected: 1 });
 
     await expect(
-      service.updatePhase(1, 1, {
-        name: 'Discovery',
-        description: 'Initial work',
-      }),
+      service.updatePhase(
+        1,
+        1,
+        {
+          name: 'Discovery',
+          description: 'Initial work',
+        },
+        presidencyActor,
+      ),
     ).resolves.toEqual(updatedPhase);
     expect(projectPhasesRepository.findOne).toHaveBeenCalledWith({
       where: { id: 1, projectId: 1 },
@@ -698,13 +832,16 @@ describe('ProjectsService', () => {
   });
 
   it('returns existing phases without updating when phase updates are empty', async () => {
+    projectsRepository.findOne?.mockResolvedValue(createProject());
     const phase = createProjectPhase();
 
     projectPhasesRepository.findOne
       ?.mockResolvedValueOnce(phase)
       .mockResolvedValueOnce(phase);
 
-    await expect(service.updatePhase(1, 1, {})).resolves.toEqual(phase);
+    await expect(
+      service.updatePhase(1, 1, {}, presidencyActor),
+    ).resolves.toEqual(phase);
     expect(projectPhasesRepository.update).not.toHaveBeenCalled();
     expect(projectPhasesRepository.save).not.toHaveBeenCalled();
   });
@@ -734,7 +871,7 @@ describe('ProjectsService', () => {
     projectPhasesRepository.save?.mockResolvedValue(reorderedPhaseUpdates);
 
     await expect(
-      service.reorderPhases(1, { phaseIds: [3, 1, 2] }),
+      service.reorderPhases(1, { phaseIds: [3, 1, 2] }, presidencyActor),
     ).resolves.toEqual(reorderedPhases);
     expect(projectPhasesRepository.manager.transaction).toHaveBeenCalledTimes(
       1,
@@ -759,7 +896,7 @@ describe('ProjectsService', () => {
     projectPhasesRepository.find?.mockResolvedValue(phases);
 
     await expect(
-      service.reorderPhases(1, { phaseIds: [1, 99] }),
+      service.reorderPhases(1, { phaseIds: [1, 99] }, presidencyActor),
     ).rejects.toThrow(
       new BadRequestException(
         'phaseIds must include every project phase exactly once',
@@ -779,7 +916,7 @@ describe('ProjectsService', () => {
     projectPhasesRepository.find?.mockResolvedValue(phases);
 
     await expect(
-      service.reorderPhases(1, { phaseIds: [1, 1] }),
+      service.reorderPhases(1, { phaseIds: [1, 1] }, presidencyActor),
     ).rejects.toThrow(
       new BadRequestException(
         'phaseIds must include every project phase exactly once',
@@ -805,7 +942,9 @@ describe('ProjectsService', () => {
     projectPhasesRepository.remove?.mockResolvedValue(phases[1]);
     projectPhasesRepository.save?.mockResolvedValue(remainingPhaseUpdates);
 
-    await expect(service.deletePhase(1, 2)).resolves.toBeUndefined();
+    await expect(
+      service.deletePhase(1, 2, presidencyActor),
+    ).resolves.toBeUndefined();
     expect(projectPhasesRepository.manager.transaction).toHaveBeenCalledTimes(
       1,
     );
@@ -826,7 +965,7 @@ describe('ProjectsService', () => {
     projectsRepository.findOne?.mockResolvedValue(project);
     projectPhasesRepository.find?.mockResolvedValue(phases);
 
-    await expect(service.deletePhase(1, 1)).rejects.toThrow(
+    await expect(service.deletePhase(1, 1, presidencyActor)).rejects.toThrow(
       new BadRequestException('Projects must keep at least one phase'),
     );
     expect(projectPhasesRepository.remove).not.toHaveBeenCalled();

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -1,13 +1,24 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { ObjectLiteral, Repository } from 'typeorm';
+import {
+  ILike,
+  In,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  ObjectLiteral,
+  Repository,
+} from 'typeorm';
 import { AreaService } from '../area/area.service';
 import { Area } from '../area/entities/area.entity';
+import { AreaRole } from '../common/enums/area-role.enum';
 import { DEFAULT_PROJECT_PHASES } from './constants/default-project-phases.constant';
 import { CreateProjectDto } from './dto/create-project.dto';
+import { ProjectLabel } from './entities/project-label.entity';
+import { ProjectLink } from './entities/project-link.entity';
 import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
+import { ProjectStatus } from './enums/project-status.enum';
 import { ProjectsService } from './projects.service';
 
 type RepositoryMethodMocks<T extends ObjectLiteral> = Partial<
@@ -24,6 +35,8 @@ type ProjectPhaseRepositoryMock = RepositoryMethodMocks<ProjectPhase> & {
     transaction: jest.Mock;
   };
 };
+type ProjectLabelRepositoryMock = RepositoryMethodMocks<ProjectLabel>;
+type ProjectLinkRepositoryMock = RepositoryMethodMocks<ProjectLink>;
 
 const createArea = (overrides: Partial<Area> = {}): Area => ({
   id: 1,
@@ -50,6 +63,30 @@ const createProjectPhase = (
   ...overrides,
 });
 
+const createProjectLabel = (
+  overrides: Partial<ProjectLabel> = {},
+): ProjectLabel => ({
+  id: 1,
+  name: 'Backend',
+  normalizedName: 'backend',
+  projects: [],
+  createdAt: new Date(),
+  ...overrides,
+});
+
+const createProjectLink = (
+  overrides: Partial<ProjectLink> = {},
+): ProjectLink => ({
+  id: 1,
+  name: 'Repository',
+  url: 'https://github.com/ccUnicode/UNICORE',
+  projectId: 1,
+  project: {} as Project,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
 const createProject = (overrides: Partial<Project> = {}): Project => {
   const area = overrides.area ?? createArea();
 
@@ -61,7 +98,11 @@ const createProject = (overrides: Partial<Project> = {}): Project => {
     endDate: '2026-07-01',
     areaId: area.id,
     area,
+    status: ProjectStatus.PLANNED,
+    isArchived: false,
     phases: [],
+    labels: [],
+    links: [],
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -72,6 +113,8 @@ describe('ProjectsService', () => {
   let service: ProjectsService;
   let projectsRepository: ProjectRepositoryMock;
   let projectPhasesRepository: ProjectPhaseRepositoryMock;
+  let projectLabelsRepository: ProjectLabelRepositoryMock;
+  let projectLinksRepository: ProjectLinkRepositoryMock;
 
   const mockAreaService = {
     findOne: jest.fn(),
@@ -110,9 +153,31 @@ describe('ProjectsService', () => {
         transaction: jest.fn(),
       },
     };
+    projectLabelsRepository = {
+      create: jest.fn((label: Partial<ProjectLabel>) =>
+        createProjectLabel(label),
+      ),
+      find: jest.fn(),
+      save: jest.fn(),
+    };
+    projectLinksRepository = {
+      create: jest.fn((link: Partial<ProjectLink>) => createProjectLink(link)),
+      save: jest.fn(),
+      delete: jest.fn(),
+    };
     const getRepository = jest.fn(
-      (entity: typeof Project | typeof ProjectPhase) =>
-        entity === Project ? projectsRepository : projectPhasesRepository,
+      (
+        entity:
+          | typeof Project
+          | typeof ProjectPhase
+          | typeof ProjectLabel
+          | typeof ProjectLink,
+      ) => {
+        if (entity === Project) return projectsRepository;
+        if (entity === ProjectPhase) return projectPhasesRepository;
+        if (entity === ProjectLabel) return projectLabelsRepository;
+        return projectLinksRepository;
+      },
     );
     const transaction = jest.fn(
       async (
@@ -134,6 +199,14 @@ describe('ProjectsService', () => {
         {
           provide: getRepositoryToken(ProjectPhase),
           useValue: projectPhasesRepository,
+        },
+        {
+          provide: getRepositoryToken(ProjectLabel),
+          useValue: projectLabelsRepository,
+        },
+        {
+          provide: getRepositoryToken(ProjectLink),
+          useValue: projectLinksRepository,
         },
         {
           provide: AreaService,
@@ -169,6 +242,9 @@ describe('ProjectsService', () => {
       endDate: createProjectDto.endDate,
       areaId: area.id,
       area,
+      status: ProjectStatus.PLANNED,
+      isArchived: false,
+      labels: [],
     });
     expect(projectPhasesRepository.create).toHaveBeenCalledTimes(
       DEFAULT_PROJECT_PHASES.length,
@@ -242,6 +318,63 @@ describe('ProjectsService', () => {
       endDate: null,
       areaId: area.id,
       area,
+      status: ProjectStatus.PLANNED,
+      isArchived: false,
+      labels: [],
+    });
+  });
+
+  it('creates projects with reusable labels and external links', async () => {
+    const area = createArea();
+    const backendLabel = createProjectLabel();
+    const priorityLabel = createProjectLabel({
+      id: 2,
+      name: 'Priority',
+      normalizedName: 'priority',
+    });
+    const project = createProject({
+      area,
+      status: ProjectStatus.ACTIVE,
+      labels: [backendLabel, priorityLabel],
+    });
+    const link = createProjectLink({ projectId: project.id });
+
+    mockAreaService.findOne.mockResolvedValue(area);
+    projectLabelsRepository.find?.mockResolvedValue([backendLabel]);
+    projectLabelsRepository.save?.mockResolvedValue([priorityLabel]);
+    projectsRepository.create?.mockReturnValue(project);
+    projectsRepository.save?.mockResolvedValue(project);
+    projectPhasesRepository.save?.mockResolvedValue([]);
+    projectLinksRepository.save?.mockResolvedValue([link]);
+
+    await expect(
+      service.create({
+        ...createProjectDto,
+        status: ProjectStatus.ACTIVE,
+        labels: ['Backend', 'Priority'],
+        links: [
+          {
+            name: 'Repository',
+            url: 'https://github.com/ccUnicode/UNICORE',
+          },
+        ],
+      }),
+    ).resolves.toEqual({
+      ...project,
+      phases: [],
+      links: [link],
+    });
+    expect(projectLabelsRepository.find).toHaveBeenCalledWith({
+      where: { normalizedName: In(['backend', 'priority']) },
+    });
+    expect(projectLabelsRepository.create).toHaveBeenCalledWith({
+      name: 'Priority',
+      normalizedName: 'priority',
+    });
+    expect(projectLinksRepository.create).toHaveBeenCalledWith({
+      name: 'Repository',
+      url: 'https://github.com/ccUnicode/UNICORE',
+      projectId: project.id,
     });
   });
 
@@ -289,7 +422,8 @@ describe('ProjectsService', () => {
       },
     });
     expect(projectsRepository.findAndCount).toHaveBeenCalledWith({
-      relations: ['area'],
+      where: { isArchived: false },
+      relations: ['area', 'labels', 'links'],
       order: { createdAt: 'DESC' },
       skip: 5,
       take: 5,
@@ -309,11 +443,85 @@ describe('ProjectsService', () => {
       },
     });
     expect(projectsRepository.findAndCount).toHaveBeenCalledWith({
-      relations: ['area'],
+      where: { isArchived: false },
+      relations: ['area', 'labels', 'links'],
       order: { createdAt: 'DESC' },
       skip: 0,
       take: 10,
     });
+  });
+
+  it('combines project metadata filters and includes archived projects explicitly', async () => {
+    projectsRepository.findAndCount?.mockResolvedValue([[], 0]);
+
+    await service.findAll({
+      status: ProjectStatus.ACTIVE,
+      areaId: 4,
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-30',
+      labels: ['Backend'],
+      search: 'portal',
+      archived: true,
+    });
+
+    expect(projectsRepository.findAndCount).toHaveBeenCalledWith({
+      where: {
+        isArchived: true,
+        status: ProjectStatus.ACTIVE,
+        areaId: 4,
+        name: ILike('%portal%'),
+        startDate: LessThanOrEqual('2026-06-30'),
+        endDate: MoreThanOrEqual('2026-06-01'),
+        labels: { normalizedName: In(['backend']) },
+      },
+      relations: ['area', 'labels', 'links'],
+      order: { createdAt: 'DESC' },
+      skip: 0,
+      take: 10,
+    });
+  });
+
+  it('limits area leaders to projects in their own area', async () => {
+    projectsRepository.findAndCount?.mockResolvedValue([[], 0]);
+
+    await service.findAll(
+      { areaId: 99 },
+      { role: AreaRole.DIRECTIVA_DE_AREA, areaId: '3' },
+    );
+
+    expect(projectsRepository.findAndCount).toHaveBeenCalledWith({
+      where: { isArchived: false, areaId: 3 },
+      relations: ['area', 'labels', 'links'],
+      order: { createdAt: 'DESC' },
+      skip: 0,
+      take: 10,
+    });
+  });
+
+  it('limits members to their assigned project ids', async () => {
+    projectsRepository.findAndCount?.mockResolvedValue([[], 0]);
+
+    await service.findAll(
+      {},
+      { role: AreaRole.MIEMBRO, projectIds: ['2', '7'] },
+    );
+
+    expect(projectsRepository.findAndCount).toHaveBeenCalledWith({
+      where: { isArchived: false, id: In([2, 7]) },
+      relations: ['area', 'labels', 'links'],
+      order: { createdAt: 'DESC' },
+      skip: 0,
+      take: 10,
+    });
+  });
+
+  it('rejects inverted project date filters', async () => {
+    await expect(
+      service.findAll({ dateFrom: '2026-07-01', dateTo: '2026-06-01' }),
+    ).rejects.toThrow(
+      new BadRequestException('startDate must be before or equal to endDate'),
+    );
+    expect(projectsRepository.findAndCount).not.toHaveBeenCalled();
   });
 
   it('returns project detail with phases ordered by order index', async () => {
@@ -329,7 +537,7 @@ describe('ProjectsService', () => {
     await expect(service.findOne(1)).resolves.toEqual(project);
     expect(projectsRepository.findOne).toHaveBeenCalledWith({
       where: { id: 1 },
-      relations: ['area', 'phases'],
+      relations: ['area', 'phases', 'labels', 'links'],
       order: {
         phases: {
           orderIndex: 'ASC',
@@ -343,6 +551,64 @@ describe('ProjectsService', () => {
 
     await expect(service.findOne(99)).rejects.toThrow(
       new NotFoundException('Project with ID 99 not found'),
+    );
+  });
+
+  it('replaces project metadata during updates', async () => {
+    const project = createProject();
+    const label = createProjectLabel({
+      name: 'Frontend',
+      normalizedName: 'frontend',
+    });
+    const link = createProjectLink({
+      name: 'Design',
+      url: 'https://figma.com/file/123',
+    });
+    const updatedProject = createProject({
+      name: 'Portal actualizado',
+      status: ProjectStatus.ACTIVE,
+      labels: [label],
+      links: [link],
+    });
+
+    projectsRepository.findOne
+      ?.mockResolvedValueOnce(project)
+      .mockResolvedValueOnce(updatedProject);
+    projectLabelsRepository.find?.mockResolvedValue([label]);
+    projectsRepository.save?.mockResolvedValue(project);
+    projectLinksRepository.delete?.mockResolvedValue({ affected: 1 });
+    projectLinksRepository.save?.mockResolvedValue([link]);
+
+    await expect(
+      service.update(1, {
+        name: 'Portal actualizado',
+        status: ProjectStatus.ACTIVE,
+        labels: ['Frontend'],
+        links: [{ name: 'Design', url: 'https://figma.com/file/123' }],
+      }),
+    ).resolves.toEqual(updatedProject);
+    expect(projectLinksRepository.delete).toHaveBeenCalledWith({
+      projectId: 1,
+    });
+    expect(projectsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Portal actualizado',
+        status: ProjectStatus.ACTIVE,
+        labels: [label],
+      }),
+    );
+  });
+
+  it('archives projects', async () => {
+    const project = createProject();
+    const archivedProject = createProject({ isArchived: true });
+
+    projectsRepository.findOne?.mockResolvedValue(project);
+    projectsRepository.save?.mockResolvedValue(archivedProject);
+
+    await expect(service.archive(1)).resolves.toEqual(archivedProject);
+    expect(projectsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, isArchived: true }),
     );
   });
 

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -176,6 +176,7 @@ describe('ProjectsService', () => {
       ),
       find: jest.fn(),
       save: jest.fn(),
+      upsert: jest.fn(),
     };
     projectLinksRepository = {
       create: jest.fn((link: Partial<ProjectLink>) => createProjectLink(link)),
@@ -362,8 +363,11 @@ describe('ProjectsService', () => {
     const link = createProjectLink({ projectId: project.id });
 
     mockAreaService.findOne.mockResolvedValue(area);
-    projectLabelsRepository.find?.mockResolvedValue([backendLabel]);
-    projectLabelsRepository.save?.mockResolvedValue([priorityLabel]);
+    projectLabelsRepository.find?.mockResolvedValue([
+      backendLabel,
+      priorityLabel,
+    ]);
+    projectLabelsRepository.upsert?.mockResolvedValue(undefined);
     projectsRepository.create?.mockReturnValue(project);
     projectsRepository.save?.mockResolvedValue(project);
     projectPhasesRepository.save?.mockResolvedValue([]);
@@ -392,10 +396,22 @@ describe('ProjectsService', () => {
     expect(projectLabelsRepository.find).toHaveBeenCalledWith({
       where: { normalizedName: In(['backend', 'priority']) },
     });
-    expect(projectLabelsRepository.create).toHaveBeenCalledWith({
-      name: 'Priority',
-      normalizedName: 'priority',
-    });
+    expect(projectLabelsRepository.upsert).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          name: 'Backend',
+          normalizedName: 'backend',
+        }),
+        expect.objectContaining({
+          name: 'Priority',
+          normalizedName: 'priority',
+        }),
+      ],
+      {
+        conflictPaths: ['normalizedName'],
+        skipUpdateIfNoValuesChanged: true,
+      },
+    );
     expect(projectLinksRepository.create).toHaveBeenCalledWith({
       name: 'Repository',
       url: 'https://github.com/ccUnicode/UNICORE',

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -45,8 +46,12 @@ export class ProjectsService {
     private readonly areaService: AreaService,
   ) {}
 
-  async create(createProjectDto: CreateProjectDto): Promise<Project> {
+  async create(
+    createProjectDto: CreateProjectDto,
+    accessActor: RequestAccessActor,
+  ): Promise<Project> {
     this.validateDateRange(createProjectDto);
+    this.assertAreaManagementAccess(createProjectDto.areaId, accessActor);
 
     const area = await this.areaService.findOne(createProjectDto.areaId);
     return this.projectsRepository.manager.transaction(
@@ -118,7 +123,14 @@ export class ProjectsService {
     };
   }
 
-  async findOne(id: number): Promise<Project> {
+  async findOne(id: number, accessActor: RequestAccessActor): Promise<Project> {
+    const project = await this.findProjectDetails(id);
+    this.assertProjectReadAccess(project, accessActor);
+
+    return project;
+  }
+
+  private async findProjectDetails(id: number): Promise<Project> {
     const project = await this.projectsRepository.findOne({
       where: { id },
       relations: ['area', 'phases', 'labels', 'links'],
@@ -139,12 +151,18 @@ export class ProjectsService {
   async update(
     id: number,
     updateProjectDto: UpdateProjectDto,
+    accessActor: RequestAccessActor,
   ): Promise<Project> {
-    const project = await this.findOne(id);
+    const project = await this.findProjectDetails(id);
+    this.assertProjectManagementAccess(project, accessActor);
     const startDate = updateProjectDto.startDate ?? project.startDate;
     const endDate = updateProjectDto.endDate ?? project.endDate;
 
     this.validateDateRange({ startDate, endDate });
+
+    if (updateProjectDto.areaId !== undefined) {
+      this.assertAreaManagementAccess(updateProjectDto.areaId, accessActor);
+    }
 
     const area =
       updateProjectDto.areaId !== undefined
@@ -192,18 +210,22 @@ export class ProjectsService {
       }
     });
 
-    return this.findOne(id);
+    return this.findOne(id, accessActor);
   }
 
-  async archive(id: number): Promise<Project> {
-    const project = await this.findOne(id);
+  async archive(id: number, accessActor: RequestAccessActor): Promise<Project> {
+    const project = await this.findProjectDetails(id);
+    this.assertProjectManagementAccess(project, accessActor);
     project.isArchived = true;
 
     return this.projectsRepository.save(project);
   }
 
-  async findPhases(projectId: number): Promise<ProjectPhase[]> {
-    await this.ensureProjectExists(projectId);
+  async findPhases(
+    projectId: number,
+    accessActor: RequestAccessActor,
+  ): Promise<ProjectPhase[]> {
+    await this.ensureProjectExists(projectId, accessActor);
 
     return this.findProjectPhases(projectId);
   }
@@ -211,6 +233,7 @@ export class ProjectsService {
   async createPhase(
     projectId: number,
     createProjectPhaseDto: CreateProjectPhaseDto,
+    accessActor: RequestAccessActor,
   ): Promise<ProjectPhase> {
     return this.projectPhasesRepository.manager.transaction(
       async (entityManager) => {
@@ -220,6 +243,7 @@ export class ProjectsService {
         const project = await this.findProjectForUpdate(
           projectId,
           projectsRepository,
+          accessActor,
         );
         const nextOrderIndex = await this.getNextPhaseOrderIndex(
           projectId,
@@ -240,6 +264,7 @@ export class ProjectsService {
   private async findProjectForUpdate(
     projectId: number,
     projectsRepository: Repository<Project>,
+    accessActor: RequestAccessActor,
   ): Promise<Project> {
     const project = await projectsRepository.findOne({
       where: { id: projectId },
@@ -250,6 +275,8 @@ export class ProjectsService {
       throw new NotFoundException(`Project with ID ${projectId} not found`);
     }
 
+    this.assertProjectManagementAccess(project, accessActor);
+
     return project;
   }
 
@@ -257,7 +284,9 @@ export class ProjectsService {
     projectId: number,
     phaseId: number,
     updateProjectPhaseDto: UpdateProjectPhaseDto,
+    accessActor: RequestAccessActor,
   ): Promise<ProjectPhase> {
+    await this.ensureProjectExists(projectId, accessActor, true);
     await this.findPhaseOrThrow(projectId, phaseId);
     const phaseUpdate: Partial<Pick<ProjectPhase, 'name' | 'description'>> = {};
 
@@ -282,12 +311,14 @@ export class ProjectsService {
   async reorderPhases(
     projectId: number,
     reorderProjectPhasesDto: ReorderProjectPhasesDto,
+    accessActor: RequestAccessActor,
   ): Promise<ProjectPhase[]> {
     return this.projectPhasesRepository.manager.transaction(
       async (entityManager) => {
         await this.findProjectForUpdate(
           projectId,
           entityManager.getRepository(Project),
+          accessActor,
         );
         const projectPhasesRepository =
           entityManager.getRepository(ProjectPhase);
@@ -324,12 +355,17 @@ export class ProjectsService {
     );
   }
 
-  async deletePhase(projectId: number, phaseId: number): Promise<void> {
+  async deletePhase(
+    projectId: number,
+    phaseId: number,
+    accessActor: RequestAccessActor,
+  ): Promise<void> {
     await this.projectPhasesRepository.manager.transaction(
       async (entityManager) => {
         await this.findProjectForUpdate(
           projectId,
           entityManager.getRepository(Project),
+          accessActor,
         );
         const projectPhasesRepository =
           entityManager.getRepository(ProjectPhase);
@@ -519,7 +555,11 @@ export class ProjectsService {
     return projectPhasesRepository.save(phases);
   }
 
-  private async ensureProjectExists(projectId: number): Promise<Project> {
+  private async ensureProjectExists(
+    projectId: number,
+    accessActor: RequestAccessActor,
+    requireManagement = false,
+  ): Promise<Project> {
     const project = await this.projectsRepository.findOne({
       where: { id: projectId },
     });
@@ -528,7 +568,57 @@ export class ProjectsService {
       throw new NotFoundException(`Project with ID ${projectId} not found`);
     }
 
+    if (requireManagement) {
+      this.assertProjectManagementAccess(project, accessActor);
+    } else {
+      this.assertProjectReadAccess(project, accessActor);
+    }
+
     return project;
+  }
+
+  private assertProjectReadAccess(
+    project: Project,
+    accessActor: RequestAccessActor,
+  ): void {
+    if (accessActor.role === AreaRole.MIEMBRO) {
+      if (!accessActor.projectIds?.includes(String(project.id))) {
+        throw new ForbiddenException(
+          'Project access is limited to assigned projects',
+        );
+      }
+
+      return;
+    }
+
+    this.assertProjectManagementAccess(project, accessActor);
+  }
+
+  private assertProjectManagementAccess(
+    project: Project,
+    accessActor: RequestAccessActor,
+  ): void {
+    this.assertAreaManagementAccess(project.areaId, accessActor);
+  }
+
+  private assertAreaManagementAccess(
+    areaId: number,
+    accessActor: RequestAccessActor,
+  ): void {
+    if (accessActor.role === AreaRole.PRESIDENCIA) {
+      return;
+    }
+
+    if (
+      accessActor.role === AreaRole.DIRECTIVA_DE_AREA &&
+      parseAreaId(accessActor.areaId) === areaId
+    ) {
+      return;
+    }
+
+    throw new ForbiddenException(
+      'Project management is limited to your own area',
+    );
   }
 
   private async findPhaseOrThrow(

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -483,25 +483,23 @@ export class ProjectsService {
       return [];
     }
 
-    const existingLabels = await projectLabelsRepository.find({
+    const labelCandidates = normalizedNames.map((normalizedName) =>
+      projectLabelsRepository.create({
+        name: labelsByNormalizedName.get(normalizedName),
+        normalizedName,
+      }),
+    );
+
+    await projectLabelsRepository.upsert(labelCandidates, {
+      conflictPaths: ['normalizedName'],
+      skipUpdateIfNoValuesChanged: true,
+    });
+
+    const labels = await projectLabelsRepository.find({
       where: { normalizedName: In(normalizedNames) },
     });
-    const existingNames = new Set(
-      existingLabels.map((label) => label.normalizedName),
-    );
-    const newLabels = normalizedNames
-      .filter((normalizedName) => !existingNames.has(normalizedName))
-      .map((normalizedName) =>
-        projectLabelsRepository.create({
-          name: labelsByNormalizedName.get(normalizedName),
-          normalizedName,
-        }),
-      );
-    const savedLabels =
-      newLabels.length > 0 ? await projectLabelsRepository.save(newLabels) : [];
-    const allLabels = [...existingLabels, ...savedLabels];
     const labelsByName = new Map(
-      allLabels.map((label) => [label.normalizedName, label]),
+      labels.map((label) => [label.normalizedName, label]),
     );
 
     return normalizedNames.map(

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -155,8 +155,14 @@ export class ProjectsService {
   ): Promise<Project> {
     const project = await this.findProjectDetails(id);
     this.assertProjectManagementAccess(project, accessActor);
-    const startDate = updateProjectDto.startDate ?? project.startDate;
-    const endDate = updateProjectDto.endDate ?? project.endDate;
+    const startDate =
+      updateProjectDto.startDate !== undefined
+        ? updateProjectDto.startDate
+        : project.startDate;
+    const endDate =
+      updateProjectDto.endDate !== undefined
+        ? updateProjectDto.endDate
+        : project.endDate;
 
     this.validateDateRange({ startDate, endDate });
 

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -4,17 +4,32 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import {
+  FindOptionsWhere,
+  ILike,
+  In,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  Repository,
+} from 'typeorm';
 import { AreaService } from '../area/area.service';
-import { PaginationDto } from '../common/dto/pagination.dto';
+import { AreaRole } from '../common/enums/area-role.enum';
 import { PaginatedResponse } from '../common/interfaces/paginated-response.interface';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
+import { parseAreaId } from '../common/utils/parse-area-id.util';
 import { DEFAULT_PROJECT_PHASES } from './constants/default-project-phases.constant';
 import { CreateProjectPhaseDto } from './dto/create-project-phase.dto';
+import { CreateProjectLinkDto } from './dto/create-project-link.dto';
 import { CreateProjectDto } from './dto/create-project.dto';
+import { GetProjectsFilterDto } from './dto/get-projects-filter.dto';
 import { ReorderProjectPhasesDto } from './dto/reorder-project-phases.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
 import { UpdateProjectPhaseDto } from './dto/update-project-phase.dto';
+import { ProjectLabel } from './entities/project-label.entity';
+import { ProjectLink } from './entities/project-link.entity';
 import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
+import { ProjectStatus } from './enums/project-status.enum';
 
 @Injectable()
 export class ProjectsService {
@@ -23,6 +38,10 @@ export class ProjectsService {
     private readonly projectsRepository: Repository<Project>,
     @InjectRepository(ProjectPhase)
     private readonly projectPhasesRepository: Repository<ProjectPhase>,
+    @InjectRepository(ProjectLabel)
+    private readonly projectLabelsRepository: Repository<ProjectLabel>,
+    @InjectRepository(ProjectLink)
+    private readonly projectLinksRepository: Repository<ProjectLink>,
     private readonly areaService: AreaService,
   ) {}
 
@@ -30,25 +49,36 @@ export class ProjectsService {
     this.validateDateRange(createProjectDto);
 
     const area = await this.areaService.findOne(createProjectDto.areaId);
-    const project = this.projectsRepository.create({
-      name: createProjectDto.name,
-      description: createProjectDto.description ?? null,
-      startDate: createProjectDto.startDate ?? null,
-      endDate: createProjectDto.endDate ?? null,
-      areaId: area.id,
-      area,
-    });
-
     return this.projectsRepository.manager.transaction(
       async (entityManager) => {
-        const savedProject = await entityManager
-          .getRepository(Project)
-          .save(project);
+        const projectsRepository = entityManager.getRepository(Project);
+        const labels = await this.resolveLabels(
+          createProjectDto.labels ?? [],
+          entityManager.getRepository(ProjectLabel),
+        );
+        const project = projectsRepository.create({
+          name: createProjectDto.name,
+          description: createProjectDto.description ?? null,
+          startDate: createProjectDto.startDate ?? null,
+          endDate: createProjectDto.endDate ?? null,
+          areaId: area.id,
+          area,
+          status: createProjectDto.status ?? ProjectStatus.PLANNED,
+          isArchived: false,
+          labels,
+        });
+        const savedProject = await projectsRepository.save(project);
 
         savedProject.phases = await this.createDefaultPhases(
           savedProject,
           entityManager.getRepository(ProjectPhase),
         );
+        savedProject.links = await this.replaceLinks(
+          savedProject,
+          createProjectDto.links ?? [],
+          entityManager.getRepository(ProjectLink),
+        );
+        savedProject.labels = labels;
 
         return savedProject;
       },
@@ -56,14 +86,22 @@ export class ProjectsService {
   }
 
   async findAll(
-    paginationDto: PaginationDto = {},
+    filterDto: GetProjectsFilterDto = {},
+    accessActor?: RequestAccessActor,
   ): Promise<PaginatedResponse<Project>> {
-    const page = paginationDto.page ?? 1;
-    const limit = paginationDto.limit ?? 10;
+    this.validateDateRange({
+      startDate: filterDto.dateFrom,
+      endDate: filterDto.dateTo,
+    });
+
+    const page = filterDto.page ?? 1;
+    const limit = filterDto.limit ?? 10;
     const skip = (page - 1) * limit;
+    const where = this.buildProjectFilters(filterDto, accessActor);
 
     const [data, total] = await this.projectsRepository.findAndCount({
-      relations: ['area'],
+      where,
+      relations: ['area', 'labels', 'links'],
       order: { createdAt: 'DESC' },
       skip,
       take: limit,
@@ -83,7 +121,7 @@ export class ProjectsService {
   async findOne(id: number): Promise<Project> {
     const project = await this.projectsRepository.findOne({
       where: { id },
-      relations: ['area', 'phases'],
+      relations: ['area', 'phases', 'labels', 'links'],
       order: {
         phases: {
           orderIndex: 'ASC',
@@ -96,6 +134,72 @@ export class ProjectsService {
     }
 
     return project;
+  }
+
+  async update(
+    id: number,
+    updateProjectDto: UpdateProjectDto,
+  ): Promise<Project> {
+    const project = await this.findOne(id);
+    const startDate = updateProjectDto.startDate ?? project.startDate;
+    const endDate = updateProjectDto.endDate ?? project.endDate;
+
+    this.validateDateRange({ startDate, endDate });
+
+    const area =
+      updateProjectDto.areaId !== undefined
+        ? await this.areaService.findOne(updateProjectDto.areaId)
+        : project.area;
+
+    await this.projectsRepository.manager.transaction(async (entityManager) => {
+      const projectsRepository = entityManager.getRepository(Project);
+
+      if (updateProjectDto.name !== undefined) {
+        project.name = updateProjectDto.name;
+      }
+      if (updateProjectDto.description !== undefined) {
+        project.description = updateProjectDto.description;
+      }
+      if (updateProjectDto.startDate !== undefined) {
+        project.startDate = updateProjectDto.startDate;
+      }
+      if (updateProjectDto.endDate !== undefined) {
+        project.endDate = updateProjectDto.endDate;
+      }
+      if (updateProjectDto.areaId !== undefined) {
+        project.areaId = area.id;
+        project.area = area;
+      }
+      if (updateProjectDto.status !== undefined) {
+        project.status = updateProjectDto.status;
+      }
+      if (updateProjectDto.labels !== undefined) {
+        project.labels = await this.resolveLabels(
+          updateProjectDto.labels,
+          entityManager.getRepository(ProjectLabel),
+        );
+      }
+
+      await projectsRepository.save(project);
+
+      if (updateProjectDto.links !== undefined) {
+        await this.replaceLinks(
+          project,
+          updateProjectDto.links,
+          entityManager.getRepository(ProjectLink),
+          true,
+        );
+      }
+    });
+
+    return this.findOne(id);
+  }
+
+  async archive(id: number): Promise<Project> {
+    const project = await this.findOne(id);
+    project.isArchived = true;
+
+    return this.projectsRepository.save(project);
   }
 
   async findPhases(projectId: number): Promise<ProjectPhase[]> {
@@ -264,8 +368,11 @@ export class ProjectsService {
     );
   }
 
-  private validateDateRange(createProjectDto: CreateProjectDto): void {
-    const { startDate, endDate } = createProjectDto;
+  private validateDateRange(dateRange: {
+    startDate?: string | null;
+    endDate?: string | null;
+  }): void {
+    const { startDate, endDate } = dateRange;
 
     if (!startDate || !endDate) {
       return;
@@ -276,6 +383,124 @@ export class ProjectsService {
         'startDate must be before or equal to endDate',
       );
     }
+  }
+
+  private buildProjectFilters(
+    filterDto: GetProjectsFilterDto,
+    accessActor?: RequestAccessActor,
+  ): FindOptionsWhere<Project> {
+    const where: FindOptionsWhere<Project> = {
+      isArchived: filterDto.archived ?? false,
+    };
+
+    if (filterDto.status) {
+      where.status = filterDto.status;
+    }
+    if (filterDto.areaId !== undefined) {
+      where.areaId = filterDto.areaId;
+    }
+    if (filterDto.search) {
+      where.name = ILike(`%${filterDto.search}%`);
+    }
+    if (filterDto.dateFrom) {
+      where.endDate = MoreThanOrEqual(filterDto.dateFrom);
+    }
+    if (filterDto.dateTo) {
+      where.startDate = LessThanOrEqual(filterDto.dateTo);
+    }
+    if (filterDto.labels?.length) {
+      where.labels = {
+        normalizedName: In(
+          filterDto.labels.map((label) => this.normalizeLabel(label)),
+        ),
+      };
+    }
+
+    if (accessActor?.role === AreaRole.DIRECTIVA_DE_AREA) {
+      where.areaId = parseAreaId(accessActor.areaId);
+    }
+    if (accessActor?.role === AreaRole.MIEMBRO) {
+      const projectIds = (accessActor.projectIds ?? [])
+        .map(Number)
+        .filter((id) => Number.isInteger(id) && id > 0);
+      where.id = In(projectIds.length > 0 ? projectIds : [-1]);
+    }
+
+    return where;
+  }
+
+  private async resolveLabels(
+    labelNames: string[],
+    projectLabelsRepository: Repository<ProjectLabel> = this
+      .projectLabelsRepository,
+  ): Promise<ProjectLabel[]> {
+    const labelsByNormalizedName = new Map<string, string>();
+
+    labelNames.forEach((name) => {
+      const trimmedName = name.trim();
+      labelsByNormalizedName.set(this.normalizeLabel(trimmedName), trimmedName);
+    });
+
+    const normalizedNames = [...labelsByNormalizedName.keys()];
+
+    if (normalizedNames.length === 0) {
+      return [];
+    }
+
+    const existingLabels = await projectLabelsRepository.find({
+      where: { normalizedName: In(normalizedNames) },
+    });
+    const existingNames = new Set(
+      existingLabels.map((label) => label.normalizedName),
+    );
+    const newLabels = normalizedNames
+      .filter((normalizedName) => !existingNames.has(normalizedName))
+      .map((normalizedName) =>
+        projectLabelsRepository.create({
+          name: labelsByNormalizedName.get(normalizedName),
+          normalizedName,
+        }),
+      );
+    const savedLabels =
+      newLabels.length > 0 ? await projectLabelsRepository.save(newLabels) : [];
+    const allLabels = [...existingLabels, ...savedLabels];
+    const labelsByName = new Map(
+      allLabels.map((label) => [label.normalizedName, label]),
+    );
+
+    return normalizedNames.map(
+      (normalizedName) => labelsByName.get(normalizedName) as ProjectLabel,
+    );
+  }
+
+  private async replaceLinks(
+    project: Project,
+    links: CreateProjectLinkDto[],
+    projectLinksRepository: Repository<ProjectLink> = this
+      .projectLinksRepository,
+    removeExisting = false,
+  ): Promise<ProjectLink[]> {
+    if (removeExisting) {
+      await projectLinksRepository.delete({ projectId: project.id });
+    }
+
+    if (links.length === 0) {
+      return [];
+    }
+
+    const projectLinks = links.map((link) =>
+      projectLinksRepository.create({
+        name: link.name,
+        url: link.url,
+        projectId: project.id,
+      }),
+    );
+
+    return projectLinksRepository.save(projectLinks);
+  }
+
+  private normalizeLabel(label: string): string {
+    return label.trim().toLocaleLowerCase();
   }
 
   private createDefaultPhases(

--- a/apps/backend/test/projects.e2e-spec.ts
+++ b/apps/backend/test/projects.e2e-spec.ts
@@ -1,0 +1,110 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { AreaRole } from '../src/common/enums/area-role.enum';
+import { RolesGuard } from '../src/common/guards/roles.guard';
+import { ProjectStatus } from '../src/projects/enums/project-status.enum';
+import { ProjectsController } from '../src/projects/projects.controller';
+import { ProjectsService } from '../src/projects/projects.service';
+
+describe('ProjectsController access (e2e)', () => {
+  let app: INestApplication;
+
+  const getHttpServer = (): Parameters<typeof request>[0] =>
+    app.getHttpServer() as Parameters<typeof request>[0];
+
+  const mockProjectsService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    archive: jest.fn(),
+    findPhases: jest.fn(),
+    createPhase: jest.fn(),
+    reorderPhases: jest.fn(),
+    updatePhase: jest.fn(),
+    deletePhase: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [ProjectsController],
+      providers: [
+        RolesGuard,
+        {
+          provide: ProjectsService,
+          useValue: mockProjectsService,
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('rejects project creation without an access actor', async () => {
+    await request(getHttpServer())
+      .post('/projects')
+      .send({ name: 'Portal', areaId: 1 })
+      .expect(403);
+
+    expect(mockProjectsService.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects project creation for members', async () => {
+    await request(getHttpServer())
+      .post('/projects')
+      .set('x-role', AreaRole.MIEMBRO)
+      .set('x-project-ids', '1')
+      .send({ name: 'Portal', areaId: 1 })
+      .expect(403);
+
+    expect(mockProjectsService.create).not.toHaveBeenCalled();
+  });
+
+  it('passes area leader context to project creation', async () => {
+    mockProjectsService.create.mockResolvedValue({
+      id: 1,
+      name: 'Portal',
+      areaId: 1,
+      status: ProjectStatus.PLANNED,
+    });
+
+    await request(getHttpServer())
+      .post('/projects')
+      .set('x-role', AreaRole.DIRECTIVA_DE_AREA)
+      .set('x-area-id', '1')
+      .send({ name: 'Portal', areaId: 1 })
+      .expect(201);
+
+    expect(mockProjectsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Portal', areaId: 1 }),
+      {
+        role: AreaRole.DIRECTIVA_DE_AREA,
+        areaId: '1',
+        memberId: undefined,
+        projectIds: undefined,
+      },
+    );
+  });
+
+  it('rejects project detail without an access actor', async () => {
+    await request(getHttpServer()).get('/projects/1').expect(403);
+
+    expect(mockProjectsService.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,10 @@
       "workspaces": [
         "apps/*",
         "packages/*"
-      ]
+      ],
+      "dependencies": {
+        "class-validator": "^0.14.4"
+      }
     },
     "apps/backend": {
       "version": "0.0.1",
@@ -24,7 +27,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/typeorm": "^11.0.0",
         "class-transformer": "^0.5.1",
-        "class-validator": "^0.15.1",
+        "class-validator": "^0.14.4",
         "pg": "^8.20.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -413,7 +416,7 @@
     },
     "apps/backend/node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -424,7 +427,7 @@
     },
     "apps/backend/node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1745,22 +1748,22 @@
     },
     "apps/backend/node_modules/@tsconfig/node10": {
       "version": "1.0.12",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "apps/backend/node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "apps/backend/node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "apps/backend/node_modules/@tsconfig/node16": {
       "version": "1.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "apps/backend/node_modules/@types/babel__core": {
@@ -1903,7 +1906,7 @@
     },
     "apps/backend/node_modules/@types/node": {
       "version": "22.19.15",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2144,7 +2147,7 @@
     },
     "apps/backend/node_modules/acorn-walk": {
       "version": "8.3.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -2262,7 +2265,7 @@
     },
     "apps/backend/node_modules/arg": {
       "version": "4.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "apps/backend/node_modules/array-timsort": {
@@ -2789,7 +2792,7 @@
     },
     "apps/backend/node_modules/create-require": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "apps/backend/node_modules/dedent": {
@@ -2857,7 +2860,7 @@
     },
     "apps/backend/node_modules/diff": {
       "version": "4.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -4311,7 +4314,7 @@
     },
     "apps/backend/node_modules/make-error": {
       "version": "1.3.6",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "apps/backend/node_modules/makeerror": {
@@ -5508,7 +5511,7 @@
     },
     "apps/backend/node_modules/ts-node": {
       "version": "10.9.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -5829,7 +5832,7 @@
     },
     "apps/backend/node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "apps/backend/node_modules/v8-to-istanbul": {
@@ -5978,7 +5981,7 @@
     },
     "apps/backend/node_modules/yn": {
       "version": "3.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6997,7 +7000,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -7007,7 +7010,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -8265,7 +8268,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -8735,9 +8738,9 @@
       "license": "MIT"
     },
     "node_modules/class-validator": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
-      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
+      "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.15.3",
@@ -12780,7 +12783,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12861,7 +12864,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "dependencies": {
+    "class-validator": "^0.14.4"
+  },
   "scripts": {
     "lint": "npm run lint --workspaces --if-present",
     "type-check": "npm run type-check --workspaces --if-present",


### PR DESCRIPTION
## Summary
This PR adds project metadata, external links, and filtering support.
The goal is to make projects easier to classify, discover, and scope by status, area, date range, labels, archived state, and user access.

## Related Issue / Requirement
- Issue: UNI2-21
- GitHub Issue: #22
- Requirement: project metadata, links, and filtering

## What Changed
- Added project status support.
- Added project labels with normalized reusable label records and conflict-safe concurrent resolution.
- Added external project links with name and URL validation.
- Added project update and archive endpoints.
- Updated project creation to accept labels, links, and status.
- Updated project listing to support filters by status, area, date range, labels, archived state, and project name search.
- Hid archived projects by default unless explicitly requested.
- Updated project access scope so listings, details, mutations, and phase operations respect presidencia, directiva, and miembro visibility rules.
- Added explicit role requirements to every project route.
- Prevented directiva users from creating, moving, updating, or archiving projects outside their area.
- Updated project detail retrieval to include area, labels, links, and phases.
- Restored runtime DTO validation with a Nest-compatible `class-validator` version.
- Added DTO validation for metadata, links, filters, partial updates, nullable dates, and nested link values.
- Added unit and HTTP tests for metadata, filtering, access scope, route roles, runtime validation, concurrent label resolution, and nullable date updates.

## How to Test
- Run `npm test --workspace apps/backend -- --runInBand`.
- Run `npm test`.
- Run `npm run lint`.
- Run `npm run type-check`.
- Run `npm run build`.
- Run `npm run test:e2e --workspace apps/backend -- --runInBand test/projects.e2e-spec.ts`.
- Verify that `POST /projects` can create projects with labels, links, and status.
- Verify that `GET /projects` filters by status, area, date range, labels, archived state, and search.
- Verify that archived projects are hidden by default.
- Verify that project listing and detail access respect user scope.
- Verify that directiva users cannot manage projects outside their area.
- Verify that `GET /projects/:id` returns labels and links.
- Verify that `PATCH /projects/:id` updates metadata, labels, links, and nullable dates.
- Verify that `PATCH /projects/:id/archive` archives an authorized project.

## Screenshots / Evidence
Local verification:
- Full test suite: 14 suites and 135 tests passed.
- Project authorization HTTP tests: 4 tests passed.

<img width="805" height="644" alt="image" src="https://github.com/user-attachments/assets/3357c6f8-8362-420d-a93a-6c34fbb94e9b" />

- `npm run lint`: OK.

<img width="525" height="252" alt="image" src="https://github.com/user-attachments/assets/571aca1b-9888-4f91-ae56-797be8b2fac4" />

- `npm run type-check`: OK.

<img width="739" height="242" alt="image" src="https://github.com/user-attachments/assets/ac768bce-63eb-4866-a0fa-f02fb165e3c0" />

- `npm run build`: OK.

<img width="746" height="563" alt="image" src="https://github.com/user-attachments/assets/ba1c1b3a-56a1-4fb8-94d4-15fbc7bea6e4" />
