### PR TITLE
Uni2 18 featprojects complete project detail edit status and archive

### DIFF
--- a/apps/backend/src/projects/dto/create-project.dto.spec.ts
+++ b/apps/backend/src/projects/dto/create-project.dto.spec.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata';
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
-import { ProjectStatus } from '../enums/project-status.enum';
 import { CreateProjectDto } from './create-project.dto';
 
 const validProjectPayload = {
@@ -83,7 +82,6 @@ describe('CreateProjectDto', () => {
   it('accepts and normalizes project metadata', async () => {
     const dto = plainToInstance(CreateProjectDto, {
       ...validProjectPayload,
-      status: ProjectStatus.ACTIVE,
       labels: ['  Backend  ', 'Priority'],
       links: [
         {

--- a/apps/backend/src/projects/dto/create-project.dto.ts
+++ b/apps/backend/src/projects/dto/create-project.dto.ts
@@ -4,7 +4,6 @@ import {
   ArrayUnique,
   IsArray,
   IsDateString,
-  IsEnum,
   IsInt,
   IsNotEmpty,
   IsOptional,
@@ -13,7 +12,6 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
-import { ProjectStatus } from '../enums/project-status.enum';
 import { CreateProjectLinkDto } from './create-project-link.dto';
 
 const trimString = ({ value }: { value: unknown }) =>
@@ -51,10 +49,6 @@ export class CreateProjectDto {
   @IsInt()
   @Min(1)
   areaId: number;
-
-  @IsOptional()
-  @IsEnum(ProjectStatus)
-  status?: ProjectStatus;
 
   @IsOptional()
   @Transform(trimStringArray)

--- a/apps/backend/src/projects/dto/update-project.dto.spec.ts
+++ b/apps/backend/src/projects/dto/update-project.dto.spec.ts
@@ -67,4 +67,10 @@ describe('UpdateProjectDto', () => {
       ).rejects.toMatchObject({ status: 400 });
     },
   );
+
+  it('rejects unsupported project statuses', async () => {
+    await expect(
+      validationPipe.transform({ status: 'draft' }, bodyMetadata),
+    ).rejects.toMatchObject({ status: 400 });
+  });
 });

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -681,6 +681,14 @@ describe('ProjectsService', () => {
     );
   });
 
+  it('rejects project updates without any fields', async () => {
+    await expect(service.update(1, {}, presidencyActor)).rejects.toThrow(
+      new BadRequestException('At least one project field must be provided'),
+    );
+    expect(projectsRepository.findOne).not.toHaveBeenCalled();
+    expect(projectsRepository.save).not.toHaveBeenCalled();
+  });
+
   it('validates date updates using cleared nullable boundaries', async () => {
     const project = createProject({
       startDate: '2026-07-01',

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -357,7 +357,6 @@ describe('ProjectsService', () => {
     });
     const project = createProject({
       area,
-      status: ProjectStatus.ACTIVE,
       labels: [backendLabel, priorityLabel],
     });
     const link = createProjectLink({ projectId: project.id });
@@ -377,7 +376,6 @@ describe('ProjectsService', () => {
       service.create(
         {
           ...createProjectDto,
-          status: ProjectStatus.ACTIVE,
           labels: ['Backend', 'Priority'],
           links: [
             {

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -68,7 +68,7 @@ export class ProjectsService {
           endDate: createProjectDto.endDate ?? null,
           areaId: area.id,
           area,
-          status: createProjectDto.status ?? ProjectStatus.PLANNED,
+          status: ProjectStatus.PLANNED,
           isArchived: false,
           labels,
         });

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -153,6 +153,16 @@ export class ProjectsService {
     updateProjectDto: UpdateProjectDto,
     accessActor: RequestAccessActor,
   ): Promise<Project> {
+    const hasUpdates = Object.values(updateProjectDto).some(
+      (value) => value !== undefined,
+    );
+
+    if (!hasUpdates) {
+      throw new BadRequestException(
+        'At least one project field must be provided',
+      );
+    }
+
     const project = await this.findProjectDetails(id);
     this.assertProjectManagementAccess(project, accessActor);
     const startDate =

--- a/apps/backend/test/projects.e2e-spec.ts
+++ b/apps/backend/test/projects.e2e-spec.ts
@@ -102,6 +102,35 @@ describe('ProjectsController access (e2e)', () => {
     );
   });
 
+  it('does not accept a client-supplied initial project status', async () => {
+    mockProjectsService.create.mockResolvedValue({
+      id: 1,
+      name: 'Portal',
+      areaId: 1,
+      status: ProjectStatus.PLANNED,
+    });
+
+    await request(getHttpServer())
+      .post('/projects')
+      .set('x-role', AreaRole.PRESIDENCIA)
+      .send({
+        name: 'Portal',
+        areaId: 1,
+        status: ProjectStatus.ACTIVE,
+      })
+      .expect(201);
+
+    expect(mockProjectsService.create).toHaveBeenCalledWith(
+      { name: 'Portal', areaId: 1 },
+      {
+        role: AreaRole.PRESIDENCIA,
+        areaId: undefined,
+        memberId: undefined,
+        projectIds: undefined,
+      },
+    );
+  });
+
   it('rejects project detail without an access actor', async () => {
     await request(getHttpServer()).get('/projects/1').expect(403);
 


### PR DESCRIPTION
## Summary
This PR completes the remaining safeguards for the project detail, edit, status, and archive flow.

The goal is to ensure that every project starts in a predictable lifecycle state and that invalid project updates are rejected before any data is changed.

## Related Issue / Requirement
- Issue: UNI2-18
- GitHub Issue: #19

## What Changed
- Enforced `planned` as the initial status for every new project.
- Removed client control over the initial project status in `POST /projects`.
- Rejected empty `PATCH /projects/:id` requests before querying or saving data.
- Added validation coverage for unsupported project statuses.
- Added HTTP regression coverage to ensure client-supplied initial statuses are ignored.
- Preserved the existing project detail, update, status, archive, access-control, and archived-list behavior.

## How to Test
From the repository root:

- Run `npm test --workspace apps/backend -- --runInBand`.
- Run `npm run test:e2e --workspace apps/backend -- --runInBand test/projects.e2e-spec.ts`.
- Run `npm run lint`.
- Run `npm run type-check`.
- Run `npm run build`.

Manual checks:

- Verify that `POST /projects` always creates a project with `status: planned`, even when the request includes another status.
- Verify that `PATCH /projects/:id` rejects an empty body with `400 Bad Request`.
- Verify that `PATCH /projects/:id` accepts a valid project update, including a valid status change.
- Verify that `PATCH /projects/:id/archive` archives the project without physically deleting it.
- Verify that archived projects are excluded from the default project list.

## Screenshots / Evidence

- Full backend test suite: 16 suites and 154 tests passed.
<img width="394" height="115" alt="image" src="https://github.com/user-attachments/assets/44dba1aa-3c9d-4a09-9e8f-580fff132643" />

## Notes
- Project lifecycle endpoints and scoped access rules were already present in the project module; this PR closes the remaining validation and initial-state gaps for UNI2-18.
- No database migration is required.