### PR TITLE
Uni2 27 feattasks implement task domain assignees statuses and

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AreaMembershipsModule } from './area-memberships/area-memberships.modul
 import { ProjectsModule } from './projects/projects.module';
 import { MigrateMemberRolesAndAreas1787788800000 } from './migrations/1787788800000-MigrateMemberRolesAndAreas';
 import { AuthModule } from './auth/auth.module';
+import { TasksModule } from './tasks/tasks.module';
 
 @Module({
   imports: [
@@ -42,6 +43,7 @@ import { AuthModule } from './auth/auth.module';
     AreaMembershipsModule,
     ProjectsModule,
     AuthModule,
+    TasksModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/projects/entities/project-phase.entity.ts
+++ b/apps/backend/src/projects/entities/project-phase.entity.ts
@@ -4,10 +4,12 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { Project } from './project.entity';
+import { Task } from '../../tasks/entities/task.entity';
 
 @Entity('project_phases')
 export class ProjectPhase {
@@ -32,6 +34,9 @@ export class ProjectPhase {
   })
   @JoinColumn({ name: 'project_id' })
   project: Project;
+
+  @OneToMany(() => Task, (task) => task.phase)
+  tasks?: Task[];
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/apps/backend/src/projects/entities/project.entity.ts
+++ b/apps/backend/src/projects/entities/project.entity.ts
@@ -16,6 +16,7 @@ import { ProjectLabel } from './project-label.entity';
 import { ProjectLink } from './project-link.entity';
 import { ProjectMembership } from './project-membership.entity';
 import { ProjectPhase } from './project-phase.entity';
+import { Task } from '../../tasks/entities/task.entity';
 
 @Entity('projects')
 export class Project {
@@ -63,6 +64,9 @@ export class Project {
 
   @OneToMany(() => ProjectMembership, (membership) => membership.project)
   memberships: ProjectMembership[];
+
+  @OneToMany(() => Task, (task) => task.project)
+  tasks?: Task[];
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/apps/backend/src/projects/projects.module.ts
+++ b/apps/backend/src/projects/projects.module.ts
@@ -9,6 +9,7 @@ import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
+import { TaskAssignee } from '../tasks/entities/task-assignee.entity';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { ProjectsService } from './projects.service';
       ProjectLink,
       ProjectMembership,
       Member,
+      TaskAssignee,
     ]),
   ],
   controllers: [ProjectsController],

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -32,6 +32,7 @@ import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 import { ProjectStatus } from './enums/project-status.enum';
 import { ProjectsService } from './projects.service';
+import { TaskAssignee } from '../tasks/entities/task-assignee.entity';
 
 type RepositoryMethodMocks<T extends ObjectLiteral> = Partial<
   Record<Exclude<keyof Repository<T>, 'manager'>, jest.Mock>
@@ -51,6 +52,7 @@ type ProjectLabelRepositoryMock = RepositoryMethodMocks<ProjectLabel>;
 type ProjectLinkRepositoryMock = RepositoryMethodMocks<ProjectLink>;
 type ProjectMembershipRepositoryMock = RepositoryMethodMocks<ProjectMembership>;
 type MemberRepositoryMock = RepositoryMethodMocks<Member>;
+type TaskAssigneeRepositoryMock = RepositoryMethodMocks<TaskAssignee>;
 
 const createArea = (overrides: Partial<Area> = {}): Area => ({
   id: 1,
@@ -199,6 +201,7 @@ describe('ProjectsService', () => {
   let projectLinksRepository: ProjectLinkRepositoryMock;
   let projectMembershipsRepository: ProjectMembershipRepositoryMock;
   let membersRepository: MemberRepositoryMock;
+  let taskAssigneesRepository: TaskAssigneeRepositoryMock;
 
   const mockAreaService = {
     findOne: jest.fn(),
@@ -260,6 +263,9 @@ describe('ProjectsService', () => {
     membersRepository = {
       findOne: jest.fn(),
     };
+    taskAssigneesRepository = {
+      findOne: jest.fn(),
+    };
     const getRepository = jest.fn(
       (
         entity:
@@ -268,13 +274,15 @@ describe('ProjectsService', () => {
           | typeof ProjectLabel
           | typeof ProjectLink
           | typeof ProjectMembership
-          | typeof Member,
+          | typeof Member
+          | typeof TaskAssignee,
       ) => {
         if (entity === Project) return projectsRepository;
         if (entity === ProjectPhase) return projectPhasesRepository;
         if (entity === ProjectLabel) return projectLabelsRepository;
         if (entity === ProjectMembership) return projectMembershipsRepository;
         if (entity === Member) return membersRepository;
+        if (entity === TaskAssignee) return taskAssigneesRepository;
         return projectLinksRepository;
       },
     );
@@ -314,6 +322,10 @@ describe('ProjectsService', () => {
         {
           provide: getRepositoryToken(Member),
           useValue: membersRepository,
+        },
+        {
+          provide: getRepositoryToken(TaskAssignee),
+          useValue: taskAssigneesRepository,
         },
         {
           provide: AreaService,
@@ -1356,6 +1368,27 @@ describe('ProjectsService', () => {
       expect(projectMembershipsRepository.remove).toHaveBeenCalledWith(
         membership,
       );
+      expect(taskAssigneesRepository.findOne).toHaveBeenCalledWith({
+        where: { projectMembershipId: membership.id },
+        select: ['id'],
+      });
+    });
+
+    it('rejects removing a member that still owns task assignments', async () => {
+      const membership = createProjectMembership();
+
+      projectsRepository.findOne?.mockResolvedValue(createProject());
+      projectMembershipsRepository.findOne?.mockResolvedValue(membership);
+      taskAssigneesRepository.findOne?.mockResolvedValue({ id: 1 });
+
+      await expect(
+        service.removeTeamMember(1, 1, presidencyActor),
+      ).rejects.toThrow(
+        new BadRequestException(
+          'Reassign member tasks before removing them from the project team',
+        ),
+      );
+      expect(projectMembershipsRepository.remove).not.toHaveBeenCalled();
     });
 
     it('rejects when the membership does not exist', async () => {

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -39,6 +39,7 @@ import { ProjectMembership } from './entities/project-membership.entity';
 import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 import { ProjectStatus } from './enums/project-status.enum';
+import { TaskAssignee } from '../tasks/entities/task-assignee.entity';
 
 @Injectable()
 export class ProjectsService {
@@ -55,6 +56,8 @@ export class ProjectsService {
     private readonly projectMembershipsRepository: Repository<ProjectMembership>,
     @InjectRepository(Member)
     private readonly membersRepository: Repository<Member>,
+    @InjectRepository(TaskAssignee)
+    private readonly taskAssigneesRepository: Repository<TaskAssignee>,
     private readonly areaService: AreaService,
   ) {}
 
@@ -569,6 +572,17 @@ export class ProjectsService {
     if (!membership) {
       throw new NotFoundException(
         `Membership for member ${memberId} in project ${projectId} not found`,
+      );
+    }
+
+    const taskAssignment = await this.taskAssigneesRepository.findOne({
+      where: { projectMembershipId: membership.id },
+      select: ['id'],
+    });
+
+    if (taskAssignment) {
+      throw new BadRequestException(
+        'Reassign member tasks before removing them from the project team',
       );
     }
 

--- a/apps/backend/src/tasks/dto/create-task.dto.spec.ts
+++ b/apps/backend/src/tasks/dto/create-task.dto.spec.ts
@@ -1,0 +1,39 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateTaskDto } from './create-task.dto';
+
+const validTaskPayload = {
+  projectId: 1,
+  title: 'Implementar endpoint',
+  dueDate: '2026-02-28',
+  assigneeIds: [1],
+};
+
+describe('CreateTaskDto', () => {
+  it('accepts a real due date in YYYY-MM-DD format', async () => {
+    const dto = plainToInstance(CreateTaskDto, validTaskPayload);
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it.each(['2026-02-30', '2026-2-28', '2026-02-28T10:00:00Z'])(
+    'rejects invalid due date %s',
+    async (dueDate) => {
+      const dto = plainToInstance(CreateTaskDto, {
+        ...validTaskPayload,
+        dueDate,
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            property: 'dueDate',
+          }),
+        ]),
+      );
+    },
+  );
+});

--- a/apps/backend/src/tasks/dto/create-task.dto.ts
+++ b/apps/backend/src/tasks/dto/create-task.dto.ts
@@ -1,0 +1,61 @@
+import { Transform, Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { TaskPriority } from '../enums/task-priority.enum';
+
+const trimString = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+export class CreateTaskDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  projectId: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  phaseId?: number;
+
+  @Transform(trimString)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  title: string;
+
+  @IsOptional()
+  @Transform(trimString)
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @IsOptional()
+  @IsEnum(TaskPriority)
+  priority?: TaskPriority;
+
+  @IsOptional()
+  @IsDateString()
+  dueDate?: string;
+
+  @Type(() => Number)
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(50)
+  @ArrayUnique()
+  @IsInt({ each: true })
+  @Min(1, { each: true })
+  assigneeIds: number[];
+}

--- a/apps/backend/src/tasks/dto/create-task.dto.ts
+++ b/apps/backend/src/tasks/dto/create-task.dto.ts
@@ -28,7 +28,7 @@ export class CreateTaskDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
-  phaseId?: number;
+  phaseId?: number | null;
 
   @Transform(trimString)
   @IsString()
@@ -40,15 +40,15 @@ export class CreateTaskDto {
   @Transform(trimString)
   @IsString()
   @MaxLength(2000)
-  description?: string;
+  description?: string | null;
 
   @IsOptional()
   @IsEnum(TaskPriority)
-  priority?: TaskPriority;
+  priority?: TaskPriority | null;
 
   @IsOptional()
   @IsDateString()
-  dueDate?: string;
+  dueDate?: string | null;
 
   @Type(() => Number)
   @IsArray()

--- a/apps/backend/src/tasks/dto/create-task.dto.ts
+++ b/apps/backend/src/tasks/dto/create-task.dto.ts
@@ -10,6 +10,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  Matches,
   MaxLength,
   Min,
 } from 'class-validator';
@@ -47,7 +48,8 @@ export class CreateTaskDto {
   priority?: TaskPriority | null;
 
   @IsOptional()
-  @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  @IsDateString({ strict: true, strictSeparator: true })
   dueDate?: string | null;
 
   @Type(() => Number)

--- a/apps/backend/src/tasks/dto/get-tasks-filter.dto.ts
+++ b/apps/backend/src/tasks/dto/get-tasks-filter.dto.ts
@@ -1,0 +1,32 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+import { TaskPriority } from '../enums/task-priority.enum';
+import { TaskStatus } from '../enums/task-status.enum';
+
+export class GetTasksFilterDto extends PaginationDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  projectId: number;
+
+  @IsOptional()
+  @IsEnum(TaskStatus)
+  status?: TaskStatus;
+
+  @IsOptional()
+  @IsEnum(TaskPriority)
+  priority?: TaskPriority;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  phaseId?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  assigneeId?: number;
+}

--- a/apps/backend/src/tasks/dto/set-task-assignees.dto.ts
+++ b/apps/backend/src/tasks/dto/set-task-assignees.dto.ts
@@ -1,0 +1,20 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
+  IsInt,
+  Min,
+} from 'class-validator';
+
+export class SetTaskAssigneesDto {
+  @Type(() => Number)
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(50)
+  @ArrayUnique()
+  @IsInt({ each: true })
+  @Min(1, { each: true })
+  memberIds: number[];
+}

--- a/apps/backend/src/tasks/dto/update-task-status.dto.ts
+++ b/apps/backend/src/tasks/dto/update-task-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { TaskStatus } from '../enums/task-status.enum';
+
+export class UpdateTaskStatusDto {
+  @IsEnum(TaskStatus)
+  status: TaskStatus;
+}

--- a/apps/backend/src/tasks/dto/update-task.dto.spec.ts
+++ b/apps/backend/src/tasks/dto/update-task.dto.spec.ts
@@ -1,0 +1,29 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateTaskDto } from './update-task.dto';
+
+describe('UpdateTaskDto', () => {
+  it.each(['2028-02-29', null])('accepts due date %s', async (dueDate) => {
+    const dto = plainToInstance(UpdateTaskDto, { dueDate });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it.each(['2026-02-30', '2026/02/28', '2026-02-28T10:00:00Z'])(
+    'rejects invalid due date %s',
+    async (dueDate) => {
+      const dto = plainToInstance(UpdateTaskDto, { dueDate });
+
+      const errors = await validate(dto);
+
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            property: 'dueDate',
+          }),
+        ]),
+      );
+    },
+  );
+});

--- a/apps/backend/src/tasks/dto/update-task.dto.ts
+++ b/apps/backend/src/tasks/dto/update-task.dto.ts
@@ -1,0 +1,47 @@
+import { Transform, Type } from 'class-transformer';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { TaskPriority } from '../enums/task-priority.enum';
+
+const isDefined = (_object: unknown, value: unknown) => value !== undefined;
+const isDefinedAndNotNull = (_object: unknown, value: unknown) =>
+  value !== undefined && value !== null;
+const trimString = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+export class UpdateTaskDto {
+  @ValidateIf(isDefined)
+  @Transform(trimString)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  title?: string;
+
+  @ValidateIf(isDefinedAndNotNull)
+  @Transform(trimString)
+  @IsString()
+  @MaxLength(2000)
+  description?: string | null;
+
+  @ValidateIf(isDefined)
+  @IsEnum(TaskPriority)
+  priority?: TaskPriority;
+
+  @ValidateIf(isDefinedAndNotNull)
+  @IsDateString()
+  dueDate?: string | null;
+
+  @ValidateIf(isDefinedAndNotNull)
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  phaseId?: number | null;
+}

--- a/apps/backend/src/tasks/dto/update-task.dto.ts
+++ b/apps/backend/src/tasks/dto/update-task.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsNotEmpty,
   IsString,
+  Matches,
   MaxLength,
   Min,
   ValidateIf,
@@ -36,7 +37,8 @@ export class UpdateTaskDto {
   priority?: TaskPriority;
 
   @ValidateIf(isDefinedAndNotNull)
-  @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  @IsDateString({ strict: true, strictSeparator: true })
   dueDate?: string | null;
 
   @ValidateIf(isDefinedAndNotNull)

--- a/apps/backend/src/tasks/entities/task-assignee.entity.ts
+++ b/apps/backend/src/tasks/entities/task-assignee.entity.ts
@@ -38,7 +38,7 @@ export class TaskAssignee {
   projectMembershipId: number;
 
   @ManyToOne(() => ProjectMembership, {
-    onDelete: 'CASCADE',
+    onDelete: 'RESTRICT',
     nullable: false,
   })
   @JoinColumn({ name: 'project_membership_id' })

--- a/apps/backend/src/tasks/entities/task-assignee.entity.ts
+++ b/apps/backend/src/tasks/entities/task-assignee.entity.ts
@@ -1,0 +1,38 @@
+import {
+  CreateDateColumn,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import { Member } from '../../members/member.entity';
+import { Task } from './task.entity';
+
+@Entity('task_assignees')
+@Unique(['taskId', 'memberId'])
+export class TaskAssignee {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ name: 'task_id', type: 'int' })
+  taskId: number;
+
+  @ManyToOne(() => Task, (task) => task.assignees, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'task_id' })
+  task: Task;
+
+  @Column({ name: 'member_id', type: 'int' })
+  memberId: number;
+
+  @ManyToOne(() => Member, { onDelete: 'CASCADE', nullable: false })
+  @JoinColumn({ name: 'member_id' })
+  member: Member;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/apps/backend/src/tasks/entities/task-assignee.entity.ts
+++ b/apps/backend/src/tasks/entities/task-assignee.entity.ts
@@ -2,6 +2,7 @@ import {
   CreateDateColumn,
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -13,6 +14,7 @@ import { Task } from './task.entity';
 
 @Entity('task_assignees')
 @Unique(['taskId', 'memberId'])
+@Index('IDX_task_assignees_member_task', ['memberId', 'taskId'])
 export class TaskAssignee {
   @PrimaryGeneratedColumn('increment')
   id: number;

--- a/apps/backend/src/tasks/entities/task-assignee.entity.ts
+++ b/apps/backend/src/tasks/entities/task-assignee.entity.ts
@@ -8,6 +8,7 @@ import {
   Unique,
 } from 'typeorm';
 import { Member } from '../../members/member.entity';
+import { ProjectMembership } from '../../projects/entities/project-membership.entity';
 import { Task } from './task.entity';
 
 @Entity('task_assignees')
@@ -32,6 +33,16 @@ export class TaskAssignee {
   @ManyToOne(() => Member, { onDelete: 'CASCADE', nullable: false })
   @JoinColumn({ name: 'member_id' })
   member: Member;
+
+  @Column({ name: 'project_membership_id', type: 'int' })
+  projectMembershipId: number;
+
+  @ManyToOne(() => ProjectMembership, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'project_membership_id' })
+  projectMembership: ProjectMembership;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/apps/backend/src/tasks/entities/task.entity.ts
+++ b/apps/backend/src/tasks/entities/task.entity.ts
@@ -1,0 +1,69 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ProjectPhase } from '../../projects/entities/project-phase.entity';
+import { Project } from '../../projects/entities/project.entity';
+import { TaskPriority } from '../enums/task-priority.enum';
+import { TaskStatus } from '../enums/task-status.enum';
+import { TaskAssignee } from './task-assignee.entity';
+
+@Entity('tasks')
+export class Task {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  title: string;
+
+  @Column({ type: 'varchar', length: 2000, nullable: true })
+  description: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: TaskPriority,
+    default: TaskPriority.MEDIUM,
+  })
+  priority: TaskPriority;
+
+  @Column({ name: 'due_date', type: 'date', nullable: true })
+  dueDate: string | null;
+
+  @Column({ type: 'enum', enum: TaskStatus, default: TaskStatus.TODO })
+  status: TaskStatus;
+
+  @Column({ name: 'project_id', type: 'int' })
+  projectId: number;
+
+  @ManyToOne(() => Project, (project) => project.tasks, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'project_id' })
+  project: Project;
+
+  @Column({ name: 'phase_id', type: 'int', nullable: true })
+  phaseId: number | null;
+
+  @ManyToOne(() => ProjectPhase, (phase) => phase.tasks, {
+    onDelete: 'SET NULL',
+    nullable: true,
+  })
+  @JoinColumn({ name: 'phase_id' })
+  phase: ProjectPhase | null;
+
+  @OneToMany(() => TaskAssignee, (assignee) => assignee.task)
+  assignees: TaskAssignee[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/apps/backend/src/tasks/enums/task-priority.enum.ts
+++ b/apps/backend/src/tasks/enums/task-priority.enum.ts
@@ -1,0 +1,6 @@
+export enum TaskPriority {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+  URGENT = 'urgent',
+}

--- a/apps/backend/src/tasks/enums/task-status.enum.ts
+++ b/apps/backend/src/tasks/enums/task-status.enum.ts
@@ -1,0 +1,6 @@
+export enum TaskStatus {
+  TODO = 'todo',
+  IN_PROGRESS = 'in_progress',
+  IN_REVIEW = 'in_review',
+  DONE = 'done',
+}

--- a/apps/backend/src/tasks/tasks.controller.spec.ts
+++ b/apps/backend/src/tasks/tasks.controller.spec.ts
@@ -1,0 +1,163 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource } from 'typeorm';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { TaskPriority } from './enums/task-priority.enum';
+import { TaskStatus } from './enums/task-status.enum';
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
+
+const getControllerMethod = (methodName: keyof TasksController) => {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    TasksController.prototype,
+    methodName,
+  );
+
+  if (!descriptor) {
+    throw new Error(`Missing TasksController method: ${String(methodName)}`);
+  }
+
+  return descriptor.value as object;
+};
+
+const accessActor = {
+  role: AreaRole.PRESIDENCIA,
+  memberId: '1',
+};
+
+describe('TasksController', () => {
+  let controller: TasksController;
+
+  const tasksService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    updateStatus: jest.fn(),
+    setAssignees: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TasksController],
+      providers: [
+        { provide: TasksService, useValue: tasksService },
+        {
+          provide: DataSource,
+          useValue: {
+            getRepository: jest.fn().mockReturnValue({
+              findOne: jest.fn().mockResolvedValue(null),
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(TasksController);
+  });
+
+  it('creates tasks through the service', async () => {
+    const dto = {
+      projectId: 1,
+      title: 'Implementar endpoint',
+      priority: TaskPriority.HIGH,
+      assigneeIds: [2],
+    };
+    const task = { id: 1, ...dto, status: TaskStatus.TODO };
+
+    tasksService.create.mockResolvedValue(task);
+
+    await expect(controller.create(dto, accessActor)).resolves.toEqual(task);
+    expect(tasksService.create).toHaveBeenCalledWith(dto, accessActor);
+  });
+
+  it('lists tasks through the service', async () => {
+    const filter = { projectId: 1, status: TaskStatus.TODO };
+    const response = {
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, lastPage: 0 },
+    };
+
+    tasksService.findAll.mockResolvedValue(response);
+
+    await expect(controller.findAll(filter, accessActor)).resolves.toEqual(
+      response,
+    );
+    expect(tasksService.findAll).toHaveBeenCalledWith(filter, accessActor);
+  });
+
+  it('gets task detail through the service', async () => {
+    tasksService.findOne.mockResolvedValue({ id: 1 });
+
+    await expect(controller.findOne(1, accessActor)).resolves.toEqual({
+      id: 1,
+    });
+    expect(tasksService.findOne).toHaveBeenCalledWith(1, accessActor);
+  });
+
+  it('updates task fields through the service', async () => {
+    const dto = { title: 'Endpoint actualizado' };
+
+    tasksService.update.mockResolvedValue({ id: 1, ...dto });
+
+    await expect(controller.update(1, dto, accessActor)).resolves.toEqual({
+      id: 1,
+      ...dto,
+    });
+    expect(tasksService.update).toHaveBeenCalledWith(1, dto, accessActor);
+  });
+
+  it('changes task status through the service', async () => {
+    const dto = { status: TaskStatus.IN_PROGRESS };
+
+    tasksService.updateStatus.mockResolvedValue({ id: 1, ...dto });
+
+    await expect(controller.updateStatus(1, dto, accessActor)).resolves.toEqual(
+      { id: 1, ...dto },
+    );
+    expect(tasksService.updateStatus).toHaveBeenCalledWith(1, dto, accessActor);
+  });
+
+  it('reassigns task members through the service', async () => {
+    const dto = { memberIds: [2, 3] };
+
+    tasksService.setAssignees.mockResolvedValue({ id: 1 });
+
+    await expect(controller.setAssignees(1, dto, accessActor)).resolves.toEqual(
+      { id: 1 },
+    );
+    expect(tasksService.setAssignees).toHaveBeenCalledWith(1, dto, accessActor);
+  });
+
+  describe('access metadata', () => {
+    it('uses RolesGuard at controller level', () => {
+      const guards = Reflect.getMetadata(
+        GUARDS_METADATA,
+        TasksController,
+      ) as Array<new (...args: unknown[]) => unknown>;
+
+      expect(guards).toContain(RolesGuard);
+    });
+
+    it.each([
+      'create',
+      'findAll',
+      'findOne',
+      'update',
+      'updateStatus',
+      'setAssignees',
+    ] as const)('declares authenticated roles for %s', (methodName) => {
+      expect(
+        Reflect.getMetadata(ROLES_KEY, getControllerMethod(methodName)),
+      ).toEqual([
+        AreaRole.PRESIDENCIA,
+        AreaRole.DIRECTIVA_DE_AREA,
+        AreaRole.MIEMBRO,
+      ]);
+    });
+  });
+});

--- a/apps/backend/src/tasks/tasks.controller.ts
+++ b/apps/backend/src/tasks/tasks.controller.ts
@@ -1,0 +1,91 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { CurrentAccessActor } from '../common/decorators/current-access-actor.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { RolesGuard } from '../common/guards/roles.guard';
+import type { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { GetTasksFilterDto } from './dto/get-tasks-filter.dto';
+import { SetTaskAssigneesDto } from './dto/set-task-assignees.dto';
+import { UpdateTaskStatusDto } from './dto/update-task-status.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+import { TasksService } from './tasks.service';
+
+const TASK_ROLES = [
+  AreaRole.PRESIDENCIA,
+  AreaRole.DIRECTIVA_DE_AREA,
+  AreaRole.MIEMBRO,
+];
+
+@Controller('tasks')
+@UseGuards(RolesGuard)
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Post()
+  @Roles(...TASK_ROLES)
+  create(
+    @Body() createTaskDto: CreateTaskDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.tasksService.create(createTaskDto, accessActor);
+  }
+
+  @Get()
+  @Roles(...TASK_ROLES)
+  findAll(
+    @Query() filterDto: GetTasksFilterDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.tasksService.findAll(filterDto, accessActor);
+  }
+
+  @Get(':id')
+  @Roles(...TASK_ROLES)
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.tasksService.findOne(id, accessActor);
+  }
+
+  @Patch(':id/status')
+  @Roles(...TASK_ROLES)
+  updateStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateTaskStatusDto: UpdateTaskStatusDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.tasksService.updateStatus(id, updateTaskStatusDto, accessActor);
+  }
+
+  @Patch(':id/assignees')
+  @Roles(...TASK_ROLES)
+  setAssignees(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() setTaskAssigneesDto: SetTaskAssigneesDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.tasksService.setAssignees(id, setTaskAssigneesDto, accessActor);
+  }
+
+  @Patch(':id')
+  @Roles(...TASK_ROLES)
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateTaskDto: UpdateTaskDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.tasksService.update(id, updateTaskDto, accessActor);
+  }
+}

--- a/apps/backend/src/tasks/tasks.module.ts
+++ b/apps/backend/src/tasks/tasks.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AccessControlModule } from '../common/access-control.module';
+import { ProjectMembership } from '../projects/entities/project-membership.entity';
+import { ProjectPhase } from '../projects/entities/project-phase.entity';
+import { Project } from '../projects/entities/project.entity';
+import { TaskAssignee } from './entities/task-assignee.entity';
+import { Task } from './entities/task.entity';
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
+
+@Module({
+  imports: [
+    AccessControlModule,
+    TypeOrmModule.forFeature([
+      Task,
+      TaskAssignee,
+      Project,
+      ProjectPhase,
+      ProjectMembership,
+    ]),
+  ],
+  controllers: [TasksController],
+  providers: [TasksService],
+  exports: [TasksService],
+})
+export class TasksModule {}

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { In } from 'typeorm';
+import { FindOperator, In } from 'typeorm';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { ProjectRole } from '../common/enums/project-role.enum';
 import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
@@ -421,7 +421,6 @@ describe('TasksService', () => {
     });
 
     projectsRepository.findOne.mockResolvedValue(createProject());
-    taskAssigneesRepository.find.mockResolvedValue([{ taskId: 1 }]);
     tasksRepository.findAndCount.mockResolvedValue([[task], 1]);
 
     const result = await service.findAll(
@@ -430,20 +429,23 @@ describe('TasksService', () => {
     );
 
     expect(result.data[0].assignees).toHaveLength(2);
-    expect(taskAssigneesRepository.find).toHaveBeenCalledWith({
-      where: { memberId: 1, task: { projectId: 1 } },
-      select: ['taskId'],
-    });
-    expect(tasksRepository.findAndCount).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { projectId: 1, id: In([1]) },
-      }),
+    expect(taskAssigneesRepository.find).not.toHaveBeenCalled();
+    const [{ where }] = tasksRepository.findAndCount.mock.calls[0] as [
+      { where: { projectId: number; id: FindOperator<number> } },
+    ];
+    expect(where.projectId).toBe(1);
+    expect(where.id.type).toBe('raw');
+    expect(where.id.objectLiteralParameters).toEqual({ assigneeId: 1 });
+    expect(where.id.getSql?.('Task.id')).toBe(
+      'EXISTS (SELECT 1 FROM task_assignees task_assignee_filter ' +
+        'WHERE task_assignee_filter.task_id = Task.id ' +
+        'AND task_assignee_filter.member_id = :assigneeId)',
     );
   });
 
-  it('returns an empty page without loading tasks when an assignee has no matches', async () => {
+  it('lets the paginated query return an empty page when an assignee has no matches', async () => {
     projectsRepository.findOne.mockResolvedValue(createProject());
-    taskAssigneesRepository.find.mockResolvedValue([]);
+    tasksRepository.findAndCount.mockResolvedValue([[], 0]);
 
     await expect(
       service.findAll(
@@ -454,7 +456,13 @@ describe('TasksService', () => {
       data: [],
       meta: { total: 0, page: 2, limit: 5, lastPage: 0 },
     });
-    expect(tasksRepository.findAndCount).not.toHaveBeenCalled();
+    expect(taskAssigneesRepository.find).not.toHaveBeenCalled();
+    expect(tasksRepository.findAndCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 5,
+        take: 5,
+      }),
+    );
   });
 
   it('rejects phase filters from another project', async () => {

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -441,6 +441,36 @@ describe('TasksService', () => {
     );
   });
 
+  it('returns an empty page without loading tasks when an assignee has no matches', async () => {
+    projectsRepository.findOne.mockResolvedValue(createProject());
+    taskAssigneesRepository.find.mockResolvedValue([]);
+
+    await expect(
+      service.findAll(
+        { projectId: 1, assigneeId: 99, page: 2, limit: 5 },
+        presidencyActor,
+      ),
+    ).resolves.toEqual({
+      data: [],
+      meta: { total: 0, page: 2, limit: 5, lastPage: 0 },
+    });
+    expect(tasksRepository.findAndCount).not.toHaveBeenCalled();
+  });
+
+  it('rejects phase filters from another project', async () => {
+    projectsRepository.findOne.mockResolvedValue(createProject());
+    projectPhasesRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.findAll({ projectId: 1, phaseId: 99 }, presidencyActor),
+    ).rejects.toThrow(
+      new BadRequestException(
+        'Project phase with ID 99 does not belong to project 1',
+      ),
+    );
+    expect(tasksRepository.findAndCount).not.toHaveBeenCalled();
+  });
+
   it('rejects task reads outside member project participation', async () => {
     tasksRepository.findOne.mockResolvedValue(createTask());
     projectMembershipsRepository.findOne.mockResolvedValue(null);

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -1,0 +1,447 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { In } from 'typeorm';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { ProjectRole } from '../common/enums/project-role.enum';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
+import { MemberActivityStatus } from '../members/enums/member-activity-status.enum';
+import { MemberAvailabilityStatus } from '../members/enums/member-availability-status.enum';
+import { Member } from '../members/member.entity';
+import { ProjectMembership } from '../projects/entities/project-membership.entity';
+import { ProjectPhase } from '../projects/entities/project-phase.entity';
+import { Project } from '../projects/entities/project.entity';
+import { ProjectStatus } from '../projects/enums/project-status.enum';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { TaskAssignee } from './entities/task-assignee.entity';
+import { Task } from './entities/task.entity';
+import { TaskPriority } from './enums/task-priority.enum';
+import { TaskStatus } from './enums/task-status.enum';
+import { TasksService } from './tasks.service';
+
+const createMember = (overrides: Partial<Member> = {}): Member =>
+  ({
+    id: 1,
+    institution: 'UNI',
+    studentCode: '20200001',
+    firstNames: 'Ana',
+    lastNames: 'Torres',
+    major: 'Ingeniería de Sistemas',
+    birthDate: '2000-01-01',
+    cycle: 8,
+    activityStatus: MemberActivityStatus.ACTIVE,
+    availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
+    skills: [],
+    memberships: [],
+    projectMemberships: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }) as Member;
+
+const createProject = (overrides: Partial<Project> = {}): Project =>
+  ({
+    id: 1,
+    name: 'Portal de miembros',
+    description: null,
+    startDate: null,
+    endDate: null,
+    areaId: 1,
+    status: ProjectStatus.ACTIVE,
+    isArchived: false,
+    phases: [],
+    labels: [],
+    links: [],
+    memberships: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }) as Project;
+
+const createPhase = (overrides: Partial<ProjectPhase> = {}): ProjectPhase =>
+  ({
+    id: 10,
+    name: 'Execution',
+    description: null,
+    orderIndex: 2,
+    projectId: 1,
+    project: createProject(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }) as ProjectPhase;
+
+const createMembership = (
+  overrides: Partial<ProjectMembership> = {},
+): ProjectMembership =>
+  ({
+    id: 1,
+    projectId: 1,
+    memberId: 1,
+    role: ProjectRole.MEMBER,
+    project: createProject(),
+    member: createMember(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }) as ProjectMembership;
+
+const createTaskAssignee = (
+  overrides: Partial<TaskAssignee> = {},
+): TaskAssignee =>
+  ({
+    id: 1,
+    taskId: 1,
+    memberId: 1,
+    task: {} as Task,
+    member: createMember(),
+    createdAt: new Date(),
+    ...overrides,
+  }) as TaskAssignee;
+
+const createTask = (overrides: Partial<Task> = {}): Task => {
+  const project = overrides.project ?? createProject();
+
+  return {
+    id: 1,
+    title: 'Implementar endpoint',
+    description: null,
+    priority: TaskPriority.MEDIUM,
+    dueDate: null,
+    status: TaskStatus.TODO,
+    projectId: project.id,
+    project,
+    phaseId: null,
+    phase: null,
+    assignees: [createTaskAssignee()],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+};
+
+const presidencyActor: RequestAccessActor = {
+  role: AreaRole.PRESIDENCIA,
+  memberId: '99',
+};
+const areaLeaderActor: RequestAccessActor = {
+  role: AreaRole.DIRECTIVA_DE_AREA,
+  areaId: '1',
+  memberId: '2',
+};
+const memberActor: RequestAccessActor = {
+  role: AreaRole.MIEMBRO,
+  memberId: '1',
+  projectIds: ['1'],
+};
+
+describe('TasksService', () => {
+  let service: TasksService;
+  let tasksRepository: {
+    create: jest.Mock;
+    save: jest.Mock;
+    findOne: jest.Mock;
+    findAndCount: jest.Mock;
+    manager: { transaction: jest.Mock };
+  };
+  let taskAssigneesRepository: Record<string, jest.Mock>;
+  let projectsRepository: Record<string, jest.Mock>;
+  let projectPhasesRepository: Record<string, jest.Mock>;
+  let projectMembershipsRepository: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    tasksRepository = {
+      create: jest.fn((task: Partial<Task>) => createTask(task)),
+      save: jest.fn((task: Task) => Promise.resolve(task)),
+      findOne: jest.fn(),
+      findAndCount: jest.fn(),
+      manager: { transaction: jest.fn() },
+    };
+    taskAssigneesRepository = {
+      create: jest.fn((assignee: Partial<TaskAssignee>) =>
+        createTaskAssignee(assignee),
+      ),
+      save: jest.fn((assignees: TaskAssignee[]) => Promise.resolve(assignees)),
+      delete: jest.fn(),
+    };
+    projectsRepository = {
+      findOne: jest.fn(),
+    };
+    projectPhasesRepository = {
+      findOne: jest.fn(),
+    };
+    projectMembershipsRepository = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    const getRepository = jest.fn((entity: unknown) => {
+      if (entity === Task) return tasksRepository;
+      if (entity === TaskAssignee) return taskAssigneesRepository;
+      if (entity === Project) return projectsRepository;
+      if (entity === ProjectPhase) return projectPhasesRepository;
+      return projectMembershipsRepository;
+    });
+    tasksRepository.manager.transaction = jest.fn(
+      (
+        callback: (manager: { getRepository: typeof getRepository }) => unknown,
+      ) => Promise.resolve(callback({ getRepository })),
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TasksService,
+        { provide: getRepositoryToken(Task), useValue: tasksRepository },
+        {
+          provide: getRepositoryToken(TaskAssignee),
+          useValue: taskAssigneesRepository,
+        },
+        { provide: getRepositoryToken(Project), useValue: projectsRepository },
+        {
+          provide: getRepositoryToken(ProjectPhase),
+          useValue: projectPhasesRepository,
+        },
+        {
+          provide: getRepositoryToken(ProjectMembership),
+          useValue: projectMembershipsRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get(TasksService);
+  });
+
+  describe('create', () => {
+    const createTaskDto: CreateTaskDto = {
+      projectId: 1,
+      phaseId: 10,
+      title: 'Implementar endpoint',
+      assigneeIds: [1],
+    };
+
+    it('creates a ToDo task with eligible project assignees', async () => {
+      const project = createProject();
+      const phase = createPhase();
+      const membership = createMembership();
+      const savedTask = createTask({ phaseId: phase.id, phase });
+
+      projectsRepository.findOne.mockResolvedValue(project);
+      projectPhasesRepository.findOne.mockResolvedValue(phase);
+      projectMembershipsRepository.find.mockResolvedValue([membership]);
+      tasksRepository.findOne.mockResolvedValue(savedTask);
+
+      await expect(
+        service.create(createTaskDto, presidencyActor),
+      ).resolves.toEqual(savedTask);
+      expect(tasksRepository.create).toHaveBeenCalledWith({
+        projectId: 1,
+        phaseId: 10,
+        title: 'Implementar endpoint',
+        description: null,
+        priority: TaskPriority.MEDIUM,
+        dueDate: null,
+        status: TaskStatus.TODO,
+      });
+      expect(projectsRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+        lock: { mode: 'pessimistic_write' },
+      });
+      expect(projectMembershipsRepository.find).toHaveBeenCalledWith({
+        where: { projectId: 1, memberId: In([1]) },
+        relations: ['member'],
+      });
+      expect(taskAssigneesRepository.save).toHaveBeenCalledWith([
+        expect.objectContaining({ taskId: 1, memberId: 1 }),
+      ]);
+    });
+
+    it('allows a project representative to create tasks', async () => {
+      const representative = createMembership({
+        role: ProjectRole.REPRESENTATIVE,
+      });
+
+      projectsRepository.findOne.mockResolvedValue(createProject());
+      projectPhasesRepository.findOne.mockResolvedValue(createPhase());
+      projectMembershipsRepository.findOne.mockResolvedValue(representative);
+      projectMembershipsRepository.find.mockResolvedValue([representative]);
+      tasksRepository.findOne.mockResolvedValue(createTask());
+
+      await expect(service.create(createTaskDto, memberActor)).resolves.toEqual(
+        expect.objectContaining({ id: 1 }),
+      );
+    });
+
+    it('rejects regular project members that try to create tasks', async () => {
+      projectsRepository.findOne.mockResolvedValue(createProject());
+      projectMembershipsRepository.findOne.mockResolvedValue(
+        createMembership(),
+      );
+
+      await expect(service.create(createTaskDto, memberActor)).rejects.toThrow(
+        new ForbiddenException(
+          'Task management requires a project representative role',
+        ),
+      );
+      expect(tasksRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects Directiva access to projects from another area', async () => {
+      projectsRepository.findOne.mockResolvedValue(
+        createProject({ areaId: 2 }),
+      );
+
+      await expect(
+        service.create(createTaskDto, areaLeaderActor),
+      ).rejects.toThrow(
+        new ForbiddenException(
+          'Task access is limited to projects in your own area',
+        ),
+      );
+      expect(tasksRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects phases from another project', async () => {
+      projectsRepository.findOne.mockResolvedValue(createProject());
+      projectPhasesRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.create(createTaskDto, presidencyActor),
+      ).rejects.toThrow(
+        new BadRequestException(
+          'Project phase with ID 10 does not belong to project 1',
+        ),
+      );
+      expect(tasksRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects assignees that are not project members', async () => {
+      projectsRepository.findOne.mockResolvedValue(createProject());
+      projectPhasesRepository.findOne.mockResolvedValue(createPhase());
+      projectMembershipsRepository.find.mockResolvedValue([]);
+
+      await expect(
+        service.create(createTaskDto, presidencyActor),
+      ).rejects.toThrow(
+        new BadRequestException('Member 1 does not belong to project 1'),
+      );
+      expect(tasksRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects unavailable assignees', async () => {
+      const membership = createMembership({
+        member: createMember({
+          availabilityStatus: MemberAvailabilityStatus.NOT_AVAILABLE,
+        }),
+      });
+
+      projectsRepository.findOne.mockResolvedValue(createProject());
+      projectPhasesRepository.findOne.mockResolvedValue(createPhase());
+      projectMembershipsRepository.find.mockResolvedValue([membership]);
+
+      await expect(
+        service.create(createTaskDto, presidencyActor),
+      ).rejects.toThrow(
+        new BadRequestException('Member 1 is not eligible for task assignment'),
+      );
+      expect(tasksRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  it('lists only tasks from a project the actor can access', async () => {
+    const task = createTask();
+    const membership = createMembership();
+
+    projectsRepository.findOne.mockResolvedValue(createProject());
+    projectMembershipsRepository.findOne.mockResolvedValue(membership);
+    tasksRepository.findAndCount.mockResolvedValue([[task], 1]);
+
+    await expect(
+      service.findAll({ projectId: 1, page: 1, limit: 10 }, memberActor),
+    ).resolves.toEqual({
+      data: [task],
+      meta: { total: 1, page: 1, limit: 10, lastPage: 1 },
+    });
+    expect(tasksRepository.findAndCount).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { projectId: 1 }, skip: 0, take: 10 }),
+    );
+  });
+
+  it('rejects task reads outside member project participation', async () => {
+    tasksRepository.findOne.mockResolvedValue(createTask());
+    projectMembershipsRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.findOne(1, memberActor)).rejects.toThrow(
+      new ForbiddenException(
+        'Task access is limited to projects where you participate',
+      ),
+    );
+  });
+
+  it('allows a project member to advance an adjacent task status', async () => {
+    const task = createTask({ status: TaskStatus.TODO });
+    const membership = createMembership();
+
+    tasksRepository.findOne.mockResolvedValue(task);
+    projectsRepository.findOne.mockResolvedValue(task.project);
+    projectMembershipsRepository.findOne.mockResolvedValue(membership);
+
+    await expect(
+      service.updateStatus(1, { status: TaskStatus.IN_PROGRESS }, memberActor),
+    ).resolves.toEqual(
+      expect.objectContaining({ status: TaskStatus.IN_PROGRESS }),
+    );
+    expect(tasksRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ status: TaskStatus.IN_PROGRESS }),
+    );
+  });
+
+  it('rejects status transitions that skip workflow states', async () => {
+    const task = createTask({ status: TaskStatus.TODO });
+
+    tasksRepository.findOne.mockResolvedValue(task);
+    projectsRepository.findOne.mockResolvedValue(task.project);
+    projectMembershipsRepository.findOne.mockResolvedValue(createMembership());
+
+    await expect(
+      service.updateStatus(1, { status: TaskStatus.DONE }, memberActor),
+    ).rejects.toThrow(
+      new BadRequestException('Cannot transition task from todo to done'),
+    );
+    expect(tasksRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('replaces task assignees atomically', async () => {
+    const task = createTask();
+    const memberships = [
+      createMembership({ memberId: 2, member: createMember({ id: 2 }) }),
+      createMembership({ memberId: 3, member: createMember({ id: 3 }) }),
+    ];
+
+    tasksRepository.findOne.mockResolvedValue(task);
+    projectsRepository.findOne.mockResolvedValue(task.project);
+    projectMembershipsRepository.find.mockResolvedValue(memberships);
+
+    await expect(
+      service.setAssignees(1, { memberIds: [2, 3] }, presidencyActor),
+    ).resolves.toEqual(expect.objectContaining({ id: 1 }));
+    expect(taskAssigneesRepository.delete).toHaveBeenCalledWith({ taskId: 1 });
+    expect(taskAssigneesRepository.save).toHaveBeenCalledWith([
+      expect.objectContaining({ taskId: 1, memberId: 2 }),
+      expect.objectContaining({ taskId: 1, memberId: 3 }),
+    ]);
+  });
+
+  it('rejects mutations on archived projects', async () => {
+    const task = createTask({ project: createProject({ isArchived: true }) });
+
+    tasksRepository.findOne.mockResolvedValue(task);
+    projectsRepository.findOne.mockResolvedValue(task.project);
+
+    await expect(
+      service.update(1, { title: 'Nuevo título' }, presidencyActor),
+    ).rejects.toThrow(
+      new BadRequestException('Archived projects cannot modify tasks'),
+    );
+    expect(tasksRepository.save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -278,6 +278,36 @@ describe('TasksService', () => {
       );
     });
 
+    it('creates tasks with nullable optional fields', async () => {
+      const membership = createMembership();
+
+      projectsRepository.findOne.mockResolvedValue(createProject());
+      projectMembershipsRepository.find.mockResolvedValue([membership]);
+      tasksRepository.findOne.mockResolvedValue(createTask());
+
+      await expect(
+        service.create(
+          {
+            ...createTaskDto,
+            phaseId: null,
+            description: null,
+            priority: null,
+            dueDate: null,
+          },
+          presidencyActor,
+        ),
+      ).resolves.toEqual(expect.objectContaining({ id: 1 }));
+      expect(projectPhasesRepository.findOne).not.toHaveBeenCalled();
+      expect(tasksRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phaseId: null,
+          description: null,
+          priority: TaskPriority.MEDIUM,
+          dueDate: null,
+        }),
+      );
+    });
+
     it('rejects regular project members that try to create tasks', async () => {
       projectsRepository.findOne.mockResolvedValue(createProject());
       projectMembershipsRepository.findOne.mockResolvedValue(

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -95,6 +95,8 @@ const createTaskAssignee = (
     memberId: 1,
     task: {} as Task,
     member: createMember(),
+    projectMembershipId: 1,
+    projectMembership: createMembership(),
     createdAt: new Date(),
     ...overrides,
   }) as TaskAssignee;
@@ -163,6 +165,7 @@ describe('TasksService', () => {
       ),
       save: jest.fn((assignees: TaskAssignee[]) => Promise.resolve(assignees)),
       delete: jest.fn(),
+      find: jest.fn(),
     };
     projectsRepository = {
       findOne: jest.fn(),
@@ -251,7 +254,11 @@ describe('TasksService', () => {
         relations: ['member'],
       });
       expect(taskAssigneesRepository.save).toHaveBeenCalledWith([
-        expect.objectContaining({ taskId: 1, memberId: 1 }),
+        expect.objectContaining({
+          taskId: 1,
+          memberId: 1,
+          projectMembershipId: 1,
+        }),
       ]);
     });
 
@@ -362,7 +369,45 @@ describe('TasksService', () => {
       meta: { total: 1, page: 1, limit: 10, lastPage: 1 },
     });
     expect(tasksRepository.findAndCount).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { projectId: 1 }, skip: 0, take: 10 }),
+      expect.objectContaining({
+        where: { projectId: 1 },
+        order: { createdAt: 'DESC', id: 'DESC' },
+        skip: 0,
+        take: 10,
+      }),
+    );
+  });
+
+  it('keeps every task assignee when filtering by one assignee', async () => {
+    const task = createTask({
+      assignees: [
+        createTaskAssignee(),
+        createTaskAssignee({
+          id: 2,
+          memberId: 2,
+          member: createMember({ id: 2 }),
+        }),
+      ],
+    });
+
+    projectsRepository.findOne.mockResolvedValue(createProject());
+    taskAssigneesRepository.find.mockResolvedValue([{ taskId: 1 }]);
+    tasksRepository.findAndCount.mockResolvedValue([[task], 1]);
+
+    const result = await service.findAll(
+      { projectId: 1, assigneeId: 1 },
+      presidencyActor,
+    );
+
+    expect(result.data[0].assignees).toHaveLength(2);
+    expect(taskAssigneesRepository.find).toHaveBeenCalledWith({
+      where: { memberId: 1, task: { projectId: 1 } },
+      select: ['taskId'],
+    });
+    expect(tasksRepository.findAndCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { projectId: 1, id: In([1]) },
+      }),
     );
   });
 
@@ -413,8 +458,16 @@ describe('TasksService', () => {
   it('replaces task assignees atomically', async () => {
     const task = createTask();
     const memberships = [
-      createMembership({ memberId: 2, member: createMember({ id: 2 }) }),
-      createMembership({ memberId: 3, member: createMember({ id: 3 }) }),
+      createMembership({
+        id: 2,
+        memberId: 2,
+        member: createMember({ id: 2 }),
+      }),
+      createMembership({
+        id: 3,
+        memberId: 3,
+        member: createMember({ id: 3 }),
+      }),
     ];
 
     tasksRepository.findOne.mockResolvedValue(task);
@@ -426,8 +479,16 @@ describe('TasksService', () => {
     ).resolves.toEqual(expect.objectContaining({ id: 1 }));
     expect(taskAssigneesRepository.delete).toHaveBeenCalledWith({ taskId: 1 });
     expect(taskAssigneesRepository.save).toHaveBeenCalledWith([
-      expect.objectContaining({ taskId: 1, memberId: 2 }),
-      expect.objectContaining({ taskId: 1, memberId: 3 }),
+      expect.objectContaining({
+        taskId: 1,
+        memberId: 2,
+        projectMembershipId: 2,
+      }),
+      expect.objectContaining({
+        taskId: 1,
+        memberId: 3,
+        projectMembershipId: 3,
+      }),
     ]);
   });
 

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -78,7 +78,10 @@ export class TasksService {
         );
         this.assertProjectIsActive(project);
 
-        if (createTaskDto.phaseId !== undefined) {
+        if (
+          createTaskDto.phaseId !== undefined &&
+          createTaskDto.phaseId !== null
+        ) {
           await this.findPhaseOrThrow(
             project.id,
             createTaskDto.phaseId,

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -1,0 +1,494 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FindOptionsWhere, In, Repository } from 'typeorm';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { ProjectRole } from '../common/enums/project-role.enum';
+import { PaginatedResponse } from '../common/interfaces/paginated-response.interface';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
+import { MemberActivityStatus } from '../members/enums/member-activity-status.enum';
+import { MemberAvailabilityStatus } from '../members/enums/member-availability-status.enum';
+import { Member } from '../members/member.entity';
+import { ProjectMembership } from '../projects/entities/project-membership.entity';
+import { ProjectPhase } from '../projects/entities/project-phase.entity';
+import { Project } from '../projects/entities/project.entity';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { GetTasksFilterDto } from './dto/get-tasks-filter.dto';
+import { SetTaskAssigneesDto } from './dto/set-task-assignees.dto';
+import { UpdateTaskStatusDto } from './dto/update-task-status.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+import { TaskAssignee } from './entities/task-assignee.entity';
+import { Task } from './entities/task.entity';
+import { TaskPriority } from './enums/task-priority.enum';
+import { TaskStatus } from './enums/task-status.enum';
+
+type TaskAccessMode = 'read' | 'manage' | 'status';
+
+const STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
+  [TaskStatus.TODO]: [TaskStatus.IN_PROGRESS],
+  [TaskStatus.IN_PROGRESS]: [TaskStatus.TODO, TaskStatus.IN_REVIEW],
+  [TaskStatus.IN_REVIEW]: [TaskStatus.IN_PROGRESS, TaskStatus.DONE],
+  [TaskStatus.DONE]: [TaskStatus.IN_REVIEW],
+};
+
+@Injectable()
+export class TasksService {
+  constructor(
+    @InjectRepository(Task)
+    private readonly tasksRepository: Repository<Task>,
+    @InjectRepository(TaskAssignee)
+    private readonly taskAssigneesRepository: Repository<TaskAssignee>,
+    @InjectRepository(Project)
+    private readonly projectsRepository: Repository<Project>,
+    @InjectRepository(ProjectPhase)
+    private readonly projectPhasesRepository: Repository<ProjectPhase>,
+    @InjectRepository(ProjectMembership)
+    private readonly projectMembershipsRepository: Repository<ProjectMembership>,
+  ) {}
+
+  async create(
+    createTaskDto: CreateTaskDto,
+    accessActor: RequestAccessActor,
+  ): Promise<Task> {
+    const taskId = await this.tasksRepository.manager.transaction(
+      async (entityManager) => {
+        const tasksRepository = entityManager.getRepository(Task);
+        const taskAssigneesRepository =
+          entityManager.getRepository(TaskAssignee);
+        const projectsRepository = entityManager.getRepository(Project);
+        const projectPhasesRepository =
+          entityManager.getRepository(ProjectPhase);
+        const projectMembershipsRepository =
+          entityManager.getRepository(ProjectMembership);
+        const project = await this.findProjectOrThrow(
+          createTaskDto.projectId,
+          projectsRepository,
+          true,
+        );
+
+        await this.assertProjectAccess(
+          project,
+          accessActor,
+          'manage',
+          projectMembershipsRepository,
+        );
+        this.assertProjectIsActive(project);
+
+        if (createTaskDto.phaseId !== undefined) {
+          await this.findPhaseOrThrow(
+            project.id,
+            createTaskDto.phaseId,
+            projectPhasesRepository,
+          );
+        }
+
+        const memberships = await this.validateAssignees(
+          project.id,
+          createTaskDto.assigneeIds,
+          projectMembershipsRepository,
+        );
+        const task = tasksRepository.create({
+          projectId: project.id,
+          phaseId: createTaskDto.phaseId ?? null,
+          title: createTaskDto.title,
+          description: createTaskDto.description ?? null,
+          priority: createTaskDto.priority ?? TaskPriority.MEDIUM,
+          dueDate: createTaskDto.dueDate ?? null,
+          status: TaskStatus.TODO,
+        });
+        const savedTask = await tasksRepository.save(task);
+        const assignees = memberships.map((membership) =>
+          taskAssigneesRepository.create({
+            taskId: savedTask.id,
+            memberId: membership.memberId,
+          }),
+        );
+
+        await taskAssigneesRepository.save(assignees);
+        return savedTask.id;
+      },
+    );
+
+    return this.findOne(taskId, accessActor);
+  }
+
+  async findAll(
+    filterDto: GetTasksFilterDto,
+    accessActor: RequestAccessActor,
+  ): Promise<PaginatedResponse<Task>> {
+    const project = await this.findProjectOrThrow(filterDto.projectId);
+    await this.assertProjectAccess(project, accessActor, 'read');
+
+    const page = filterDto.page ?? 1;
+    const limit = filterDto.limit ?? 10;
+    const where: FindOptionsWhere<Task> = {
+      projectId: project.id,
+      ...(filterDto.status !== undefined && { status: filterDto.status }),
+      ...(filterDto.priority !== undefined && {
+        priority: filterDto.priority,
+      }),
+      ...(filterDto.phaseId !== undefined && {
+        phaseId: filterDto.phaseId,
+      }),
+      ...(filterDto.assigneeId !== undefined && {
+        assignees: { memberId: filterDto.assigneeId },
+      }),
+    };
+    const [data, total] = await this.tasksRepository.findAndCount({
+      where,
+      relations: ['project', 'phase', 'assignees', 'assignees.member'],
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    data.forEach((task) => this.limitAssigneeFields(task));
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        lastPage: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async findOne(id: number, accessActor: RequestAccessActor): Promise<Task> {
+    const task = await this.findTaskOrThrow(id);
+    await this.assertProjectAccess(task.project, accessActor, 'read');
+    this.limitAssigneeFields(task);
+
+    return task;
+  }
+
+  async update(
+    id: number,
+    updateTaskDto: UpdateTaskDto,
+    accessActor: RequestAccessActor,
+  ): Promise<Task> {
+    if (!Object.values(updateTaskDto).some((value) => value !== undefined)) {
+      throw new BadRequestException('At least one task field must be provided');
+    }
+
+    await this.tasksRepository.manager.transaction(async (entityManager) => {
+      const tasksRepository = entityManager.getRepository(Task);
+      const projectPhasesRepository = entityManager.getRepository(ProjectPhase);
+      const projectMembershipsRepository =
+        entityManager.getRepository(ProjectMembership);
+      const task = await this.findTaskForUpdate(id, tasksRepository);
+      const project = await this.findProjectOrThrow(
+        task.projectId,
+        entityManager.getRepository(Project),
+      );
+
+      await this.assertProjectAccess(
+        project,
+        accessActor,
+        'manage',
+        projectMembershipsRepository,
+      );
+      this.assertProjectIsActive(project);
+
+      if (
+        updateTaskDto.phaseId !== undefined &&
+        updateTaskDto.phaseId !== null
+      ) {
+        await this.findPhaseOrThrow(
+          project.id,
+          updateTaskDto.phaseId,
+          projectPhasesRepository,
+        );
+      }
+
+      if (updateTaskDto.title !== undefined) {
+        task.title = updateTaskDto.title;
+      }
+      if (updateTaskDto.description !== undefined) {
+        task.description = updateTaskDto.description;
+      }
+      if (updateTaskDto.priority !== undefined) {
+        task.priority = updateTaskDto.priority;
+      }
+      if (updateTaskDto.dueDate !== undefined) {
+        task.dueDate = updateTaskDto.dueDate;
+      }
+      if (updateTaskDto.phaseId !== undefined) {
+        task.phaseId = updateTaskDto.phaseId;
+      }
+
+      await tasksRepository.save(task);
+    });
+
+    return this.findOne(id, accessActor);
+  }
+
+  async updateStatus(
+    id: number,
+    updateTaskStatusDto: UpdateTaskStatusDto,
+    accessActor: RequestAccessActor,
+  ): Promise<Task> {
+    await this.tasksRepository.manager.transaction(async (entityManager) => {
+      const tasksRepository = entityManager.getRepository(Task);
+      const projectMembershipsRepository =
+        entityManager.getRepository(ProjectMembership);
+      const task = await this.findTaskForUpdate(id, tasksRepository);
+      const project = await this.findProjectOrThrow(
+        task.projectId,
+        entityManager.getRepository(Project),
+      );
+
+      await this.assertProjectAccess(
+        project,
+        accessActor,
+        'status',
+        projectMembershipsRepository,
+      );
+      this.assertProjectIsActive(project);
+
+      if (
+        !STATUS_TRANSITIONS[task.status].includes(updateTaskStatusDto.status)
+      ) {
+        throw new BadRequestException(
+          `Cannot transition task from ${task.status} to ${updateTaskStatusDto.status}`,
+        );
+      }
+
+      task.status = updateTaskStatusDto.status;
+      await tasksRepository.save(task);
+    });
+
+    return this.findOne(id, accessActor);
+  }
+
+  async setAssignees(
+    id: number,
+    setTaskAssigneesDto: SetTaskAssigneesDto,
+    accessActor: RequestAccessActor,
+  ): Promise<Task> {
+    await this.tasksRepository.manager.transaction(async (entityManager) => {
+      const tasksRepository = entityManager.getRepository(Task);
+      const taskAssigneesRepository = entityManager.getRepository(TaskAssignee);
+      const projectMembershipsRepository =
+        entityManager.getRepository(ProjectMembership);
+      const task = await this.findTaskForUpdate(id, tasksRepository);
+      const project = await this.findProjectOrThrow(
+        task.projectId,
+        entityManager.getRepository(Project),
+      );
+
+      await this.assertProjectAccess(
+        project,
+        accessActor,
+        'manage',
+        projectMembershipsRepository,
+      );
+      this.assertProjectIsActive(project);
+
+      const memberships = await this.validateAssignees(
+        project.id,
+        setTaskAssigneesDto.memberIds,
+        projectMembershipsRepository,
+      );
+
+      await taskAssigneesRepository.delete({ taskId: task.id });
+      await taskAssigneesRepository.save(
+        memberships.map((membership) =>
+          taskAssigneesRepository.create({
+            taskId: task.id,
+            memberId: membership.memberId,
+          }),
+        ),
+      );
+    });
+
+    return this.findOne(id, accessActor);
+  }
+
+  private async findTaskOrThrow(id: number): Promise<Task> {
+    const task = await this.tasksRepository.findOne({
+      where: { id },
+      relations: ['project', 'phase', 'assignees', 'assignees.member'],
+    });
+
+    if (!task) {
+      throw new NotFoundException(`Task with ID ${id} not found`);
+    }
+
+    return task;
+  }
+
+  private async findTaskForUpdate(
+    id: number,
+    tasksRepository: Repository<Task>,
+  ): Promise<Task> {
+    const task = await tasksRepository.findOne({
+      where: { id },
+      lock: { mode: 'pessimistic_write' },
+    });
+
+    if (!task) {
+      throw new NotFoundException(`Task with ID ${id} not found`);
+    }
+
+    return task;
+  }
+
+  private async findProjectOrThrow(
+    id: number,
+    projectsRepository: Repository<Project> = this.projectsRepository,
+    lock = false,
+  ): Promise<Project> {
+    const project = await projectsRepository.findOne({
+      where: { id },
+      ...(lock && { lock: { mode: 'pessimistic_write' as const } }),
+    });
+
+    if (!project) {
+      throw new NotFoundException(`Project with ID ${id} not found`);
+    }
+
+    return project;
+  }
+
+  private async findPhaseOrThrow(
+    projectId: number,
+    phaseId: number,
+    projectPhasesRepository: Repository<ProjectPhase> = this
+      .projectPhasesRepository,
+  ): Promise<ProjectPhase> {
+    const phase = await projectPhasesRepository.findOne({
+      where: { id: phaseId, projectId },
+    });
+
+    if (!phase) {
+      throw new BadRequestException(
+        `Project phase with ID ${phaseId} does not belong to project ${projectId}`,
+      );
+    }
+
+    return phase;
+  }
+
+  private async validateAssignees(
+    projectId: number,
+    memberIds: number[],
+    projectMembershipsRepository: Repository<ProjectMembership> = this
+      .projectMembershipsRepository,
+  ): Promise<ProjectMembership[]> {
+    if (
+      memberIds.length === 0 ||
+      new Set(memberIds).size !== memberIds.length
+    ) {
+      throw new BadRequestException(
+        'Task assignees must contain unique project members',
+      );
+    }
+
+    const memberships = await projectMembershipsRepository.find({
+      where: { projectId, memberId: In(memberIds) },
+      relations: ['member'],
+    });
+    const membershipsByMemberId = new Map(
+      memberships.map((membership) => [membership.memberId, membership]),
+    );
+    const missingMemberId = memberIds.find(
+      (memberId) => !membershipsByMemberId.has(memberId),
+    );
+
+    if (missingMemberId !== undefined) {
+      throw new BadRequestException(
+        `Member ${missingMemberId} does not belong to project ${projectId}`,
+      );
+    }
+
+    const ineligibleMembership = memberships.find(
+      ({ member }) =>
+        member.activityStatus !== MemberActivityStatus.ACTIVE ||
+        member.availabilityStatus !== MemberAvailabilityStatus.AVAILABLE,
+    );
+
+    if (ineligibleMembership) {
+      throw new BadRequestException(
+        `Member ${ineligibleMembership.memberId} is not eligible for task assignment`,
+      );
+    }
+
+    return memberIds.map(
+      (memberId) => membershipsByMemberId.get(memberId) as ProjectMembership,
+    );
+  }
+
+  private async assertProjectAccess(
+    project: Project,
+    accessActor: RequestAccessActor,
+    mode: TaskAccessMode,
+    projectMembershipsRepository: Repository<ProjectMembership> = this
+      .projectMembershipsRepository,
+  ): Promise<void> {
+    if (accessActor.role === AreaRole.PRESIDENCIA) {
+      return;
+    }
+
+    if (accessActor.role === AreaRole.DIRECTIVA_DE_AREA) {
+      if (String(project.areaId) === accessActor.areaId) {
+        return;
+      }
+
+      throw new ForbiddenException(
+        'Task access is limited to projects in your own area',
+      );
+    }
+
+    const memberId = Number(accessActor.memberId);
+    if (!Number.isSafeInteger(memberId) || memberId < 1) {
+      throw new ForbiddenException(
+        'Task access requires authenticated project participation',
+      );
+    }
+
+    const membership = await projectMembershipsRepository.findOne({
+      where: { projectId: project.id, memberId },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException(
+        'Task access is limited to projects where you participate',
+      );
+    }
+
+    if (
+      mode === 'manage' &&
+      ![ProjectRole.REPRESENTATIVE, ProjectRole.SUBREPRESENTATIVE].includes(
+        membership.role,
+      )
+    ) {
+      throw new ForbiddenException(
+        'Task management requires a project representative role',
+      );
+    }
+  }
+
+  private assertProjectIsActive(project: Project): void {
+    if (project.isArchived) {
+      throw new BadRequestException('Archived projects cannot modify tasks');
+    }
+  }
+
+  private limitAssigneeFields(task: Task): void {
+    task.assignees?.sort((a, b) => a.memberId - b.memberId);
+    task.assignees?.forEach((assignee) => {
+      if (!assignee.member) {
+        return;
+      }
+
+      const { id, firstNames, lastNames } = assignee.member;
+      assignee.member = { id, firstNames, lastNames } as Member;
+    });
+  }
+}

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -105,6 +105,7 @@ export class TasksService {
           taskAssigneesRepository.create({
             taskId: savedTask.id,
             memberId: membership.memberId,
+            projectMembershipId: membership.id,
           }),
         );
 
@@ -123,10 +124,32 @@ export class TasksService {
     const project = await this.findProjectOrThrow(filterDto.projectId);
     await this.assertProjectAccess(project, accessActor, 'read');
 
+    if (filterDto.phaseId !== undefined) {
+      await this.findPhaseOrThrow(project.id, filterDto.phaseId);
+    }
+
     const page = filterDto.page ?? 1;
     const limit = filterDto.limit ?? 10;
+    let filteredTaskIds: number[] | undefined;
+
+    if (filterDto.assigneeId !== undefined) {
+      const assignments = await this.taskAssigneesRepository.find({
+        where: {
+          memberId: filterDto.assigneeId,
+          task: { projectId: project.id },
+        },
+        select: ['taskId'],
+      });
+      filteredTaskIds = assignments.map(({ taskId }) => taskId);
+
+      if (filteredTaskIds.length === 0) {
+        return this.emptyPage(page, limit);
+      }
+    }
+
     const where: FindOptionsWhere<Task> = {
       projectId: project.id,
+      ...(filteredTaskIds !== undefined && { id: In(filteredTaskIds) }),
       ...(filterDto.status !== undefined && { status: filterDto.status }),
       ...(filterDto.priority !== undefined && {
         priority: filterDto.priority,
@@ -134,14 +157,11 @@ export class TasksService {
       ...(filterDto.phaseId !== undefined && {
         phaseId: filterDto.phaseId,
       }),
-      ...(filterDto.assigneeId !== undefined && {
-        assignees: { memberId: filterDto.assigneeId },
-      }),
     };
     const [data, total] = await this.tasksRepository.findAndCount({
       where,
       relations: ['project', 'phase', 'assignees', 'assignees.member'],
-      order: { createdAt: 'DESC' },
+      order: { createdAt: 'DESC', id: 'DESC' },
       skip: (page - 1) * limit,
       take: limit,
     });
@@ -302,6 +322,7 @@ export class TasksService {
           taskAssigneesRepository.create({
             taskId: task.id,
             memberId: membership.memberId,
+            projectMembershipId: membership.id,
           }),
         ),
       );
@@ -478,6 +499,13 @@ export class TasksService {
     if (project.isArchived) {
       throw new BadRequestException('Archived projects cannot modify tasks');
     }
+  }
+
+  private emptyPage(page: number, limit: number): PaginatedResponse<Task> {
+    return {
+      data: [],
+      meta: { total: 0, page, limit, lastPage: 0 },
+    };
   }
 
   private limitAssigneeFields(task: Task): void {

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptionsWhere, In, Repository } from 'typeorm';
+import { FindOptionsWhere, In, Raw, Repository } from 'typeorm';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { ProjectRole } from '../common/enums/project-role.enum';
 import { PaginatedResponse } from '../common/interfaces/paginated-response.interface';
@@ -133,26 +133,18 @@ export class TasksService {
 
     const page = filterDto.page ?? 1;
     const limit = filterDto.limit ?? 10;
-    let filteredTaskIds: number[] | undefined;
-
-    if (filterDto.assigneeId !== undefined) {
-      const assignments = await this.taskAssigneesRepository.find({
-        where: {
-          memberId: filterDto.assigneeId,
-          task: { projectId: project.id },
-        },
-        select: ['taskId'],
-      });
-      filteredTaskIds = assignments.map(({ taskId }) => taskId);
-
-      if (filteredTaskIds.length === 0) {
-        return this.emptyPage(page, limit);
-      }
-    }
 
     const where: FindOptionsWhere<Task> = {
       projectId: project.id,
-      ...(filteredTaskIds !== undefined && { id: In(filteredTaskIds) }),
+      ...(filterDto.assigneeId !== undefined && {
+        id: Raw(
+          (taskIdAlias) =>
+            `EXISTS (SELECT 1 FROM task_assignees task_assignee_filter ` +
+            `WHERE task_assignee_filter.task_id = ${taskIdAlias} ` +
+            `AND task_assignee_filter.member_id = :assigneeId)`,
+          { assigneeId: filterDto.assigneeId },
+        ),
+      }),
       ...(filterDto.status !== undefined && { status: filterDto.status }),
       ...(filterDto.priority !== undefined && {
         priority: filterDto.priority,
@@ -502,13 +494,6 @@ export class TasksService {
     if (project.isArchived) {
       throw new BadRequestException('Archived projects cannot modify tasks');
     }
-  }
-
-  private emptyPage(page: number, limit: number): PaginatedResponse<Task> {
-    return {
-      data: [],
-      meta: { total: 0, page, limit, lastPage: 0 },
-    };
   }
 
   private limitAssigneeFields(task: Task): void {


### PR DESCRIPTION
## Summary
This PR implements the task domain for UNICORE, including task creation, updates, assignment management, status transitions, filtering, and protected access based on project membership and area roles.

It also preserves project assignment invariants by preventing members from being removed while they remain assigned to project tasks.

## Related Issue / Requirement
- Issue: UNI2-27
- GitHub Issue: #37
- Requirements:
  - Members can create and manage tasks within accessible projects.
  - Tasks support statuses, priorities, phases, due dates, and multiple assignees.
  - Task lists can be filtered by status, priority, phase, and assignee.
  - Only authorized project members can access or modify project tasks.
  - Task assignees must belong to the corresponding project.
  - Project members cannot be removed while assigned to project tasks.

## What Changed
- Added the task domain model and task-assignee relationship.
- Added task statuses: `todo`, `in_progress`, `in_review`, and `done`.
- Added task priorities: `low`, `medium`, `high`, and `urgent`.
- Added protected endpoints to:
  - Create tasks.
  - List and filter project tasks.
  - Retrieve an individual task.
  - Update task details.
  - Update task status.
  - Replace task assignees.
- Added pagination and filters for project, status, priority, phase, and assignee.
- Added validation for task input, nullable optional fields, assignee IDs, and project phases.
- Restricted task access according to the authenticated member's project membership and area role.
- Ensured task phases belong to the same project as the task.
- Ensured task assignees are active members assigned to the corresponding project.
- Preserved valid assignees when updating task data.
- Prevented project members from being removed while they remain assigned to project tasks.
- Added controller and service coverage for task workflows, authorization rules, filters, and project-assignment invariants.
- Registered the tasks module and its project relationships in the backend application.

## How to Test
From the repository root:

- Run `npm run type-check -w backend`.
- Run `npm run lint -w backend`.
- Run `npm test -w backend`.
- Run `npm run build -w backend`.

Manual API checks:

- Create a task in a project accessible to the authenticated member.
- Create tasks with and without optional phase, due date, description, and assignees.
- List tasks using the required `projectId` filter.
- Filter tasks by status, priority, phase, and assignee.
- Retrieve and update a task belonging to an accessible project.
- Change a task between `todo`, `in_progress`, `in_review`, and `done`.
- Replace the task assignee list with valid project members.
- Verify that assigning a member outside the project is rejected.
- Verify that using a phase from another project is rejected.
- Verify that members without access to the project cannot read or modify its tasks.
- Attempt to remove a project member assigned to a task and verify that the operation is rejected.
- Remove the member from all project tasks and verify that project removal can proceed.

## Screenshots / Evidence
- Backend type-check: OK.
- Backend lint: OK.
- Backend tests: OK - 24 suites and 233 tests passed.
- Backend build: OK.