### PR TITLE
feat(tasks): add comments and status change history

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -41,3 +41,38 @@ jobs:
 
       - name: Run ${{ matrix.command }}
         run: npm run ${{ matrix.command }} --workspace ${{ matrix.workspace }} --if-present
+
+  migration-integration:
+    name: backend / migration integration
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: unicore_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d unicore_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/unicore_test
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run migration integration test
+        run: npm run test:migrations --workspace apps/backend

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -19,7 +19,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:migrations": "jest --config ./test/jest-migrations.json --runInBand"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AreaMembershipsModule } from './area-memberships/area-memberships.modul
 import { ProjectsModule } from './projects/projects.module';
 import { MigrateMemberRolesAndAreas1787788800000 } from './migrations/1787788800000-MigrateMemberRolesAndAreas';
 import { RepairMemberAreaMemberships1787788800001 } from './migrations/1787788800001-RepairMemberAreaMemberships';
+import { AddTaskCollaboration1787788800002 } from './migrations/1787788800002-AddTaskCollaboration';
 import { AuthModule } from './auth/auth.module';
 import { TasksModule } from './tasks/tasks.module';
 
@@ -37,6 +38,7 @@ import { TasksModule } from './tasks/tasks.module';
           migrations: [
             MigrateMemberRolesAndAreas1787788800000,
             RepairMemberAreaMemberships1787788800001,
+            AddTaskCollaboration1787788800002,
           ],
           migrationsRun: true,
         };

--- a/apps/backend/src/migrations/1787788800002-AddTaskCollaboration.spec.ts
+++ b/apps/backend/src/migrations/1787788800002-AddTaskCollaboration.spec.ts
@@ -1,0 +1,44 @@
+import { QueryRunner } from 'typeorm';
+import { AddTaskCollaboration1787788800002 } from './1787788800002-AddTaskCollaboration';
+
+describe('AddTaskCollaboration1787788800002', () => {
+  it('creates both collaboration tables and their indexes', async () => {
+    const executedQueries: string[] = [];
+    const queryRunner = {
+      query: jest.fn((sql: string) => {
+        const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+        executedQueries.push(normalizedSql);
+        return Promise.resolve(
+          normalizedSql.startsWith('SELECT COUNT') ? [{ count: 2 }] : [],
+        );
+      }),
+    } as unknown as QueryRunner;
+
+    await new AddTaskCollaboration1787788800002().up(queryRunner);
+
+    expect(
+      executedQueries.some((sql) =>
+        sql.startsWith('CREATE TABLE IF NOT EXISTS task_comments'),
+      ),
+    ).toBe(true);
+    expect(
+      executedQueries.some((sql) =>
+        sql.startsWith('CREATE TABLE IF NOT EXISTS task_status_history'),
+      ),
+    ).toBe(true);
+    expect(
+      executedQueries.filter((sql) => sql.startsWith('CREATE INDEX')),
+    ).toHaveLength(2);
+  });
+
+  it('lets schema synchronization handle a fresh database', async () => {
+    const query = jest.fn((sql: string) =>
+      Promise.resolve(sql.includes('SELECT COUNT') ? [{ count: 0 }] : []),
+    );
+    const queryRunner = { query } as unknown as QueryRunner;
+
+    await new AddTaskCollaboration1787788800002().up(queryRunner);
+
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/migrations/1787788800002-AddTaskCollaboration.ts
+++ b/apps/backend/src/migrations/1787788800002-AddTaskCollaboration.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTaskCollaboration1787788800002 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const requiredTables = (await queryRunner.query(`
+      SELECT COUNT(*)::int AS count
+      FROM information_schema.tables
+      WHERE table_schema = current_schema()
+        AND table_name IN ('tasks', 'members');
+    `)) as { count: number }[];
+
+    // On a fresh database TypeORM synchronization creates the full schema.
+    if (Number(requiredTables[0]?.count) !== 2) {
+      return;
+    }
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS task_comments (
+        id SERIAL PRIMARY KEY,
+        task_id INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+        author_id INTEGER NOT NULL REFERENCES members(id) ON DELETE RESTRICT,
+        content VARCHAR(2000) NOT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW()
+      );
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_task_comments_task_created"
+      ON task_comments (task_id, created_at);
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS task_status_history (
+        id SERIAL PRIMARY KEY,
+        task_id INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+        previous_status tasks_status_enum NOT NULL,
+        new_status tasks_status_enum NOT NULL,
+        actor_id INTEGER NOT NULL REFERENCES members(id) ON DELETE RESTRICT,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW()
+      );
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_task_status_history_task_created"
+      ON task_status_history (task_id, created_at);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE IF EXISTS task_status_history;');
+    await queryRunner.query('DROP TABLE IF EXISTS task_comments;');
+  }
+}

--- a/apps/backend/src/tasks/dto/create-task-comment.dto.spec.ts
+++ b/apps/backend/src/tasks/dto/create-task-comment.dto.spec.ts
@@ -1,0 +1,28 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateTaskCommentDto } from './create-task-comment.dto';
+
+describe('CreateTaskCommentDto', () => {
+  it('trims a valid comment', async () => {
+    const dto = plainToInstance(CreateTaskCommentDto, {
+      content: '  Avancé con la validación.  ',
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto.content).toBe('Avancé con la validación.');
+  });
+
+  it.each(['', '   '])('rejects an empty comment: %p', async (content) => {
+    const dto = plainToInstance(CreateTaskCommentDto, { content });
+
+    await expect(validate(dto)).resolves.not.toHaveLength(0);
+  });
+
+  it('rejects comments longer than 2000 characters', async () => {
+    const dto = plainToInstance(CreateTaskCommentDto, {
+      content: 'a'.repeat(2001),
+    });
+
+    await expect(validate(dto)).resolves.not.toHaveLength(0);
+  });
+});

--- a/apps/backend/src/tasks/dto/create-task-comment.dto.ts
+++ b/apps/backend/src/tasks/dto/create-task-comment.dto.ts
@@ -1,0 +1,13 @@
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+const trimString = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+export class CreateTaskCommentDto {
+  @Transform(trimString)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  content: string;
+}

--- a/apps/backend/src/tasks/entities/task-comment.entity.ts
+++ b/apps/backend/src/tasks/entities/task-comment.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Member } from '../../members/member.entity';
+import { Task } from './task.entity';
+
+@Entity('task_comments')
+@Index('IDX_task_comments_task_created', ['taskId', 'createdAt'])
+export class TaskComment {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ name: 'task_id', type: 'int' })
+  taskId: number;
+
+  @ManyToOne(() => Task, (task) => task.comments, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'task_id' })
+  task: Task;
+
+  @Column({ name: 'author_id', type: 'int' })
+  authorId: number;
+
+  @ManyToOne(() => Member, { onDelete: 'RESTRICT', nullable: false })
+  @JoinColumn({ name: 'author_id' })
+  author: Member;
+
+  @Column({ type: 'varchar', length: 2000 })
+  content: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/apps/backend/src/tasks/entities/task-status-history.entity.ts
+++ b/apps/backend/src/tasks/entities/task-status-history.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Member } from '../../members/member.entity';
+import { TaskStatus } from '../enums/task-status.enum';
+import { Task } from './task.entity';
+
+@Entity('task_status_history')
+@Index('IDX_task_status_history_task_created', ['taskId', 'createdAt'])
+export class TaskStatusHistory {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ name: 'task_id', type: 'int' })
+  taskId: number;
+
+  @ManyToOne(() => Task, (task) => task.statusHistory, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'task_id' })
+  task: Task;
+
+  @Column({
+    name: 'previous_status',
+    type: 'enum',
+    enum: TaskStatus,
+    enumName: 'tasks_status_enum',
+  })
+  previousStatus: TaskStatus;
+
+  @Column({
+    name: 'new_status',
+    type: 'enum',
+    enum: TaskStatus,
+    enumName: 'tasks_status_enum',
+  })
+  newStatus: TaskStatus;
+
+  @Column({ name: 'actor_id', type: 'int' })
+  actorId: number;
+
+  @ManyToOne(() => Member, { onDelete: 'RESTRICT', nullable: false })
+  @JoinColumn({ name: 'actor_id' })
+  actor: Member;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/apps/backend/src/tasks/entities/task.entity.ts
+++ b/apps/backend/src/tasks/entities/task.entity.ts
@@ -13,6 +13,8 @@ import { Project } from '../../projects/entities/project.entity';
 import { TaskPriority } from '../enums/task-priority.enum';
 import { TaskStatus } from '../enums/task-status.enum';
 import { TaskAssignee } from './task-assignee.entity';
+import { TaskComment } from './task-comment.entity';
+import { TaskStatusHistory } from './task-status-history.entity';
 
 @Entity('tasks')
 export class Task {
@@ -60,6 +62,12 @@ export class Task {
 
   @OneToMany(() => TaskAssignee, (assignee) => assignee.task)
   assignees: TaskAssignee[];
+
+  @OneToMany(() => TaskComment, (comment) => comment.task)
+  comments: TaskComment[];
+
+  @OneToMany(() => TaskStatusHistory, (history) => history.task)
+  statusHistory: TaskStatusHistory[];
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/apps/backend/src/tasks/tasks.controller.spec.ts
+++ b/apps/backend/src/tasks/tasks.controller.spec.ts
@@ -37,6 +37,9 @@ describe('TasksController', () => {
     update: jest.fn(),
     updateStatus: jest.fn(),
     setAssignees: jest.fn(),
+    addComment: jest.fn(),
+    findComments: jest.fn(),
+    findStatusHistory: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -133,6 +136,31 @@ describe('TasksController', () => {
     expect(tasksService.setAssignees).toHaveBeenCalledWith(1, dto, accessActor);
   });
 
+  it('adds task comments through the service', async () => {
+    const dto = { content: 'Listo para revisar.' };
+    tasksService.addComment.mockResolvedValue({ id: 5, ...dto });
+
+    await expect(controller.addComment(1, dto, accessActor)).resolves.toEqual({
+      id: 5,
+      ...dto,
+    });
+    expect(tasksService.addComment).toHaveBeenCalledWith(1, dto, accessActor);
+  });
+
+  it('lists task comments and status history through read-only endpoints', async () => {
+    tasksService.findComments.mockResolvedValue([{ id: 1 }]);
+    tasksService.findStatusHistory.mockResolvedValue([{ id: 2 }]);
+
+    await expect(controller.findComments(1, accessActor)).resolves.toEqual([
+      { id: 1 },
+    ]);
+    await expect(controller.findStatusHistory(1, accessActor)).resolves.toEqual(
+      [{ id: 2 }],
+    );
+    expect(tasksService.findComments).toHaveBeenCalledWith(1, accessActor);
+    expect(tasksService.findStatusHistory).toHaveBeenCalledWith(1, accessActor);
+  });
+
   describe('access metadata', () => {
     it('uses RolesGuard at controller level', () => {
       const guards = Reflect.getMetadata(
@@ -150,6 +178,9 @@ describe('TasksController', () => {
       'update',
       'updateStatus',
       'setAssignees',
+      'addComment',
+      'findComments',
+      'findStatusHistory',
     ] as const)('declares authenticated roles for %s', (methodName) => {
       expect(
         Reflect.getMetadata(ROLES_KEY, getControllerMethod(methodName)),

--- a/apps/backend/src/tasks/tasks.controller.ts
+++ b/apps/backend/src/tasks/tasks.controller.ts
@@ -15,6 +15,7 @@ import { AreaRole } from '../common/enums/area-role.enum';
 import { RolesGuard } from '../common/guards/roles.guard';
 import type { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { CreateTaskDto } from './dto/create-task.dto';
+import { CreateTaskCommentDto } from './dto/create-task-comment.dto';
 import { GetTasksFilterDto } from './dto/get-tasks-filter.dto';
 import { SetTaskAssigneesDto } from './dto/set-task-assignees.dto';
 import { UpdateTaskStatusDto } from './dto/update-task-status.dto';
@@ -57,6 +58,34 @@ export class TasksController {
     @CurrentAccessActor() accessActor: RequestAccessActor,
   ) {
     return this.tasksService.findOne(id, accessActor);
+  }
+
+  @Post(':id/comments')
+  @Roles(...TASK_ROLES)
+  addComment(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() createTaskCommentDto: CreateTaskCommentDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.tasksService.addComment(id, createTaskCommentDto, accessActor);
+  }
+
+  @Get(':id/comments')
+  @Roles(...TASK_ROLES)
+  findComments(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.tasksService.findComments(id, accessActor);
+  }
+
+  @Get(':id/status-history')
+  @Roles(...TASK_ROLES)
+  findStatusHistory(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.tasksService.findStatusHistory(id, accessActor);
   }
 
   @Patch(':id/status')

--- a/apps/backend/src/tasks/tasks.module.ts
+++ b/apps/backend/src/tasks/tasks.module.ts
@@ -5,6 +5,8 @@ import { ProjectMembership } from '../projects/entities/project-membership.entit
 import { ProjectPhase } from '../projects/entities/project-phase.entity';
 import { Project } from '../projects/entities/project.entity';
 import { TaskAssignee } from './entities/task-assignee.entity';
+import { TaskComment } from './entities/task-comment.entity';
+import { TaskStatusHistory } from './entities/task-status-history.entity';
 import { Task } from './entities/task.entity';
 import { TasksController } from './tasks.controller';
 import { TasksService } from './tasks.service';
@@ -15,6 +17,8 @@ import { TasksService } from './tasks.service';
     TypeOrmModule.forFeature([
       Task,
       TaskAssignee,
+      TaskComment,
+      TaskStatusHistory,
       Project,
       ProjectPhase,
       ProjectMembership,

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -14,7 +14,9 @@ import { Project } from '../projects/entities/project.entity';
 import { ProjectStatus } from '../projects/enums/project-status.enum';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { TaskAssignee } from './entities/task-assignee.entity';
+import { TaskComment } from './entities/task-comment.entity';
 import { Task } from './entities/task.entity';
+import { TaskStatusHistory } from './entities/task-status-history.entity';
 import { TaskPriority } from './enums/task-priority.enum';
 import { TaskStatus } from './enums/task-status.enum';
 import { TasksService } from './tasks.service';
@@ -116,6 +118,8 @@ const createTask = (overrides: Partial<Task> = {}): Task => {
     phaseId: null,
     phase: null,
     assignees: [createTaskAssignee()],
+    comments: [],
+    statusHistory: [],
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -147,6 +151,8 @@ describe('TasksService', () => {
     manager: { transaction: jest.Mock };
   };
   let taskAssigneesRepository: Record<string, jest.Mock>;
+  let taskCommentsRepository: Record<string, jest.Mock>;
+  let taskStatusHistoryRepository: Record<string, jest.Mock>;
   let projectsRepository: Record<string, jest.Mock>;
   let projectPhasesRepository: Record<string, jest.Mock>;
   let projectMembershipsRepository: Record<string, jest.Mock>;
@@ -167,6 +173,25 @@ describe('TasksService', () => {
       delete: jest.fn(),
       find: jest.fn(),
     };
+    taskCommentsRepository = {
+      create: jest.fn((comment: Partial<TaskComment>) => ({
+        id: 1,
+        createdAt: new Date(),
+        ...comment,
+      })),
+      save: jest.fn((comment: TaskComment) => Promise.resolve(comment)),
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+    taskStatusHistoryRepository = {
+      create: jest.fn((history: Partial<TaskStatusHistory>) => ({
+        id: 1,
+        createdAt: new Date(),
+        ...history,
+      })),
+      save: jest.fn((history: TaskStatusHistory) => Promise.resolve(history)),
+      find: jest.fn(),
+    };
     projectsRepository = {
       findOne: jest.fn(),
     };
@@ -181,6 +206,8 @@ describe('TasksService', () => {
     const getRepository = jest.fn((entity: unknown) => {
       if (entity === Task) return tasksRepository;
       if (entity === TaskAssignee) return taskAssigneesRepository;
+      if (entity === TaskComment) return taskCommentsRepository;
+      if (entity === TaskStatusHistory) return taskStatusHistoryRepository;
       if (entity === Project) return projectsRepository;
       if (entity === ProjectPhase) return projectPhasesRepository;
       return projectMembershipsRepository;
@@ -198,6 +225,14 @@ describe('TasksService', () => {
         {
           provide: getRepositoryToken(TaskAssignee),
           useValue: taskAssigneesRepository,
+        },
+        {
+          provide: getRepositoryToken(TaskComment),
+          useValue: taskCommentsRepository,
+        },
+        {
+          provide: getRepositoryToken(TaskStatusHistory),
+          useValue: taskStatusHistoryRepository,
         },
         { provide: getRepositoryToken(Project), useValue: projectsRepository },
         {
@@ -506,6 +541,13 @@ describe('TasksService', () => {
     expect(tasksRepository.save).toHaveBeenCalledWith(
       expect.objectContaining({ status: TaskStatus.IN_PROGRESS }),
     );
+    expect(taskStatusHistoryRepository.save).toHaveBeenCalledTimes(1);
+    expect(taskStatusHistoryRepository.create).toHaveBeenCalledWith({
+      taskId: 1,
+      previousStatus: TaskStatus.TODO,
+      newStatus: TaskStatus.IN_PROGRESS,
+      actorId: 1,
+    });
   });
 
   it('rejects status transitions that skip workflow states', async () => {
@@ -521,6 +563,106 @@ describe('TasksService', () => {
       new BadRequestException('Cannot transition task from todo to done'),
     );
     expect(tasksRepository.save).not.toHaveBeenCalled();
+    expect(taskStatusHistoryRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('adds a comment with the authenticated project participant as author', async () => {
+    const task = createTask();
+    const comment = {
+      id: 1,
+      taskId: 1,
+      authorId: 1,
+      content: 'Necesitamos revisar la validación.',
+      author: createMember(),
+      createdAt: new Date(),
+    } as TaskComment;
+
+    tasksRepository.findOne.mockResolvedValue(task);
+    projectMembershipsRepository.findOne.mockResolvedValue(createMembership());
+    taskCommentsRepository.findOne.mockResolvedValue(comment);
+
+    await expect(
+      service.addComment(
+        1,
+        { content: 'Necesitamos revisar la validación.' },
+        memberActor,
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        taskId: 1,
+        authorId: 1,
+        content: 'Necesitamos revisar la validación.',
+      }),
+    );
+    expect(taskCommentsRepository.create).toHaveBeenCalledWith({
+      taskId: 1,
+      authorId: 1,
+      content: 'Necesitamos revisar la validación.',
+    });
+    expect(comment.author).toEqual({
+      id: 1,
+      firstNames: 'Ana',
+      lastNames: 'Torres',
+    });
+  });
+
+  it('rejects comment reads outside project participation', async () => {
+    tasksRepository.findOne.mockResolvedValue(createTask());
+    projectMembershipsRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.findComments(1, memberActor)).rejects.toThrow(
+      new ForbiddenException(
+        'Task access is limited to projects where you participate',
+      ),
+    );
+    expect(taskCommentsRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('rejects comment writes outside project participation', async () => {
+    tasksRepository.findOne.mockResolvedValue(createTask());
+    projectMembershipsRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.addComment(1, { content: 'No autorizado' }, memberActor),
+    ).rejects.toThrow(
+      new ForbiddenException(
+        'Task access is limited to projects where you participate',
+      ),
+    );
+    expect(taskCommentsRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('lists immutable status history with limited actor data', async () => {
+    const entry = {
+      id: 1,
+      taskId: 1,
+      previousStatus: TaskStatus.TODO,
+      newStatus: TaskStatus.IN_PROGRESS,
+      actorId: 1,
+      actor: createMember(),
+      createdAt: new Date(),
+    } as TaskStatusHistory;
+
+    tasksRepository.findOne.mockResolvedValue(createTask());
+    projectMembershipsRepository.findOne.mockResolvedValue(createMembership());
+    taskStatusHistoryRepository.find.mockResolvedValue([entry]);
+
+    await expect(service.findStatusHistory(1, memberActor)).resolves.toEqual([
+      expect.objectContaining({
+        previousStatus: TaskStatus.TODO,
+        newStatus: TaskStatus.IN_PROGRESS,
+      }),
+    ]);
+    expect(taskStatusHistoryRepository.find).toHaveBeenCalledWith({
+      where: { taskId: 1 },
+      relations: ['actor'],
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+    expect(entry.actor).toEqual({
+      id: 1,
+      firstNames: 'Ana',
+      lastNames: 'Torres',
+    });
   });
 
   it('replaces task assignees atomically', async () => {

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -171,7 +171,7 @@ describe('TasksService', () => {
       ),
       save: jest.fn((assignees: TaskAssignee[]) => Promise.resolve(assignees)),
       delete: jest.fn(),
-      find: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
     };
     taskCommentsRepository = {
       create: jest.fn((comment: Partial<TaskComment>) => ({
@@ -181,7 +181,7 @@ describe('TasksService', () => {
       })),
       save: jest.fn((comment: TaskComment) => Promise.resolve(comment)),
       findOne: jest.fn(),
-      find: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
     };
     taskStatusHistoryRepository = {
       create: jest.fn((history: Partial<TaskStatusHistory>) => ({
@@ -190,7 +190,7 @@ describe('TasksService', () => {
         ...history,
       })),
       save: jest.fn((history: TaskStatusHistory) => Promise.resolve(history)),
-      find: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
     };
     projectsRepository = {
       findOne: jest.fn(),
@@ -523,6 +523,28 @@ describe('TasksService', () => {
         'Task access is limited to projects where you participate',
       ),
     );
+  });
+
+  it('loads task collaboration in independent queries', async () => {
+    const task = createTask();
+
+    tasksRepository.findOne.mockResolvedValue(task);
+
+    await expect(service.findOne(1, presidencyActor)).resolves.toEqual(task);
+    expect(tasksRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 1 },
+      relations: ['project', 'phase', 'assignees', 'assignees.member'],
+    });
+    expect(taskCommentsRepository.find).toHaveBeenCalledWith({
+      where: { taskId: 1 },
+      relations: ['author'],
+      order: { createdAt: 'ASC', id: 'ASC' },
+    });
+    expect(taskStatusHistoryRepository.find).toHaveBeenCalledWith({
+      where: { taskId: 1 },
+      relations: ['actor'],
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
   });
 
   it('allows a project member to advance an adjacent task status', async () => {

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -17,12 +17,15 @@ import { ProjectMembership } from '../projects/entities/project-membership.entit
 import { ProjectPhase } from '../projects/entities/project-phase.entity';
 import { Project } from '../projects/entities/project.entity';
 import { CreateTaskDto } from './dto/create-task.dto';
+import { CreateTaskCommentDto } from './dto/create-task-comment.dto';
 import { GetTasksFilterDto } from './dto/get-tasks-filter.dto';
 import { SetTaskAssigneesDto } from './dto/set-task-assignees.dto';
 import { UpdateTaskStatusDto } from './dto/update-task-status.dto';
 import { UpdateTaskDto } from './dto/update-task.dto';
 import { TaskAssignee } from './entities/task-assignee.entity';
+import { TaskComment } from './entities/task-comment.entity';
 import { Task } from './entities/task.entity';
+import { TaskStatusHistory } from './entities/task-status-history.entity';
 import { TaskPriority } from './enums/task-priority.enum';
 import { TaskStatus } from './enums/task-status.enum';
 
@@ -42,6 +45,10 @@ export class TasksService {
     private readonly tasksRepository: Repository<Task>,
     @InjectRepository(TaskAssignee)
     private readonly taskAssigneesRepository: Repository<TaskAssignee>,
+    @InjectRepository(TaskComment)
+    private readonly taskCommentsRepository: Repository<TaskComment>,
+    @InjectRepository(TaskStatusHistory)
+    private readonly taskStatusHistoryRepository: Repository<TaskStatusHistory>,
     @InjectRepository(Project)
     private readonly projectsRepository: Repository<Project>,
     @InjectRepository(ProjectPhase)
@@ -262,6 +269,8 @@ export class TasksService {
       const tasksRepository = entityManager.getRepository(Task);
       const projectMembershipsRepository =
         entityManager.getRepository(ProjectMembership);
+      const taskStatusHistoryRepository =
+        entityManager.getRepository(TaskStatusHistory);
       const task = await this.findTaskForUpdate(id, tasksRepository);
       const project = await this.findProjectOrThrow(
         task.projectId,
@@ -284,11 +293,84 @@ export class TasksService {
         );
       }
 
+      const previousStatus = task.status;
       task.status = updateTaskStatusDto.status;
       await tasksRepository.save(task);
+      await taskStatusHistoryRepository.save(
+        taskStatusHistoryRepository.create({
+          taskId: task.id,
+          previousStatus,
+          newStatus: updateTaskStatusDto.status,
+          actorId: this.getActorMemberId(accessActor),
+        }),
+      );
     });
 
     return this.findOne(id, accessActor);
+  }
+
+  async addComment(
+    id: number,
+    createTaskCommentDto: CreateTaskCommentDto,
+    accessActor: RequestAccessActor,
+  ): Promise<TaskComment> {
+    const task = await this.findTaskOrThrow(id);
+    await this.assertProjectAccess(task.project, accessActor, 'read');
+    this.assertProjectIsActive(task.project);
+
+    const savedComment = await this.taskCommentsRepository.save(
+      this.taskCommentsRepository.create({
+        taskId: task.id,
+        authorId: this.getActorMemberId(accessActor),
+        content: createTaskCommentDto.content,
+      }),
+    );
+
+    const comment = await this.taskCommentsRepository.findOne({
+      where: { id: savedComment.id },
+      relations: ['author'],
+    });
+
+    if (!comment) {
+      throw new NotFoundException(
+        `Task comment with ID ${savedComment.id} not found`,
+      );
+    }
+
+    this.limitMemberFields(comment, 'author');
+    return comment;
+  }
+
+  async findComments(
+    id: number,
+    accessActor: RequestAccessActor,
+  ): Promise<TaskComment[]> {
+    const task = await this.findTaskOrThrow(id);
+    await this.assertProjectAccess(task.project, accessActor, 'read');
+
+    const comments = await this.taskCommentsRepository.find({
+      where: { taskId: task.id },
+      relations: ['author'],
+      order: { createdAt: 'ASC', id: 'ASC' },
+    });
+    comments.forEach((comment) => this.limitMemberFields(comment, 'author'));
+    return comments;
+  }
+
+  async findStatusHistory(
+    id: number,
+    accessActor: RequestAccessActor,
+  ): Promise<TaskStatusHistory[]> {
+    const task = await this.findTaskOrThrow(id);
+    await this.assertProjectAccess(task.project, accessActor, 'read');
+
+    const history = await this.taskStatusHistoryRepository.find({
+      where: { taskId: task.id },
+      relations: ['actor'],
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+    history.forEach((entry) => this.limitMemberFields(entry, 'actor'));
+    return history;
   }
 
   async setAssignees(
@@ -339,7 +421,20 @@ export class TasksService {
   private async findTaskOrThrow(id: number): Promise<Task> {
     const task = await this.tasksRepository.findOne({
       where: { id },
-      relations: ['project', 'phase', 'assignees', 'assignees.member'],
+      relations: [
+        'project',
+        'phase',
+        'assignees',
+        'assignees.member',
+        'comments',
+        'comments.author',
+        'statusHistory',
+        'statusHistory.actor',
+      ],
+      order: {
+        comments: { createdAt: 'ASC', id: 'ASC' },
+        statusHistory: { createdAt: 'DESC', id: 'DESC' },
+      },
     });
 
     if (!task) {
@@ -516,5 +611,47 @@ export class TasksService {
       const { id, firstNames, lastNames } = assignee.member;
       assignee.member = { id, firstNames, lastNames } as Member;
     });
+    task.comments?.forEach((comment) =>
+      this.limitMemberFields(comment, 'author'),
+    );
+    task.statusHistory?.forEach((entry) =>
+      this.limitMemberFields(entry, 'actor'),
+    );
+  }
+
+  private getActorMemberId(accessActor: RequestAccessActor): number {
+    const memberId = Number(accessActor.memberId);
+    if (!Number.isSafeInteger(memberId) || memberId < 1) {
+      throw new ForbiddenException('Task collaboration requires an actor');
+    }
+    return memberId;
+  }
+
+  private limitMemberFields(
+    resource: TaskComment | TaskStatusHistory,
+    relation: 'author' | 'actor',
+  ): void {
+    const member =
+      relation === 'author'
+        ? (resource as TaskComment).author
+        : (resource as TaskStatusHistory).actor;
+    if (!member) {
+      return;
+    }
+
+    const { id, firstNames, lastNames } = member;
+    if (relation === 'author') {
+      (resource as TaskComment).author = {
+        id,
+        firstNames,
+        lastNames,
+      } as Member;
+    } else {
+      (resource as TaskStatusHistory).actor = {
+        id,
+        firstNames,
+        lastNames,
+      } as Member;
+    }
   }
 }

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -194,6 +194,12 @@ export class TasksService {
   async findOne(id: number, accessActor: RequestAccessActor): Promise<Task> {
     const task = await this.findTaskOrThrow(id);
     await this.assertProjectAccess(task.project, accessActor, 'read');
+    const [comments, statusHistory] = await Promise.all([
+      this.loadComments(task.id),
+      this.loadStatusHistory(task.id),
+    ]);
+    task.comments = comments;
+    task.statusHistory = statusHistory;
     this.limitAssigneeFields(task);
 
     return task;
@@ -314,7 +320,7 @@ export class TasksService {
     createTaskCommentDto: CreateTaskCommentDto,
     accessActor: RequestAccessActor,
   ): Promise<TaskComment> {
-    const task = await this.findTaskOrThrow(id);
+    const task = await this.findTaskForAccessOrThrow(id);
     await this.assertProjectAccess(task.project, accessActor, 'read');
     this.assertProjectIsActive(task.project);
 
@@ -345,14 +351,10 @@ export class TasksService {
     id: number,
     accessActor: RequestAccessActor,
   ): Promise<TaskComment[]> {
-    const task = await this.findTaskOrThrow(id);
+    const task = await this.findTaskForAccessOrThrow(id);
     await this.assertProjectAccess(task.project, accessActor, 'read');
 
-    const comments = await this.taskCommentsRepository.find({
-      where: { taskId: task.id },
-      relations: ['author'],
-      order: { createdAt: 'ASC', id: 'ASC' },
-    });
+    const comments = await this.loadComments(task.id);
     comments.forEach((comment) => this.limitMemberFields(comment, 'author'));
     return comments;
   }
@@ -361,14 +363,10 @@ export class TasksService {
     id: number,
     accessActor: RequestAccessActor,
   ): Promise<TaskStatusHistory[]> {
-    const task = await this.findTaskOrThrow(id);
+    const task = await this.findTaskForAccessOrThrow(id);
     await this.assertProjectAccess(task.project, accessActor, 'read');
 
-    const history = await this.taskStatusHistoryRepository.find({
-      where: { taskId: task.id },
-      relations: ['actor'],
-      order: { createdAt: 'DESC', id: 'DESC' },
-    });
+    const history = await this.loadStatusHistory(task.id);
     history.forEach((entry) => this.limitMemberFields(entry, 'actor'));
     return history;
   }
@@ -421,20 +419,7 @@ export class TasksService {
   private async findTaskOrThrow(id: number): Promise<Task> {
     const task = await this.tasksRepository.findOne({
       where: { id },
-      relations: [
-        'project',
-        'phase',
-        'assignees',
-        'assignees.member',
-        'comments',
-        'comments.author',
-        'statusHistory',
-        'statusHistory.actor',
-      ],
-      order: {
-        comments: { createdAt: 'ASC', id: 'ASC' },
-        statusHistory: { createdAt: 'DESC', id: 'DESC' },
-      },
+      relations: ['project', 'phase', 'assignees', 'assignees.member'],
     });
 
     if (!task) {
@@ -442,6 +427,35 @@ export class TasksService {
     }
 
     return task;
+  }
+
+  private async findTaskForAccessOrThrow(id: number): Promise<Task> {
+    const task = await this.tasksRepository.findOne({
+      where: { id },
+      relations: ['project'],
+    });
+
+    if (!task) {
+      throw new NotFoundException(`Task with ID ${id} not found`);
+    }
+
+    return task;
+  }
+
+  private loadComments(taskId: number): Promise<TaskComment[]> {
+    return this.taskCommentsRepository.find({
+      where: { taskId },
+      relations: ['author'],
+      order: { createdAt: 'ASC', id: 'ASC' },
+    });
+  }
+
+  private loadStatusHistory(taskId: number): Promise<TaskStatusHistory[]> {
+    return this.taskStatusHistoryRepository.find({
+      where: { taskId },
+      relations: ['actor'],
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
   }
 
   private async findTaskForUpdate(

--- a/apps/backend/test/jest-migrations.json
+++ b/apps/backend/test/jest-migrations.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": "task-collaboration-migration.e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/apps/backend/test/task-collaboration-migration.e2e-spec.ts
+++ b/apps/backend/test/task-collaboration-migration.e2e-spec.ts
@@ -1,0 +1,135 @@
+import { join } from 'node:path';
+import { DataSource } from 'typeorm';
+import { AddTaskCollaboration1787788800002 } from '../src/migrations/1787788800002-AddTaskCollaboration';
+
+const databaseUrl = process.env.TEST_DATABASE_URL;
+const describeWithPostgres = databaseUrl ? describe : describe.skip;
+
+describeWithPostgres('task collaboration migration (PostgreSQL)', () => {
+  let adminDataSource: DataSource;
+  let schemaDataSource: DataSource;
+  const schema = `task_collaboration_${Date.now()}`;
+
+  beforeAll(async () => {
+    adminDataSource = new DataSource({
+      type: 'postgres',
+      url: databaseUrl,
+    });
+    await adminDataSource.initialize();
+    await adminDataSource.query(`CREATE SCHEMA "${schema}"`);
+
+    schemaDataSource = new DataSource({
+      type: 'postgres',
+      url: databaseUrl,
+      schema,
+      entities: [join(__dirname, '../src/**/*.entity.{ts,js}')],
+      synchronize: true,
+    });
+    await schemaDataSource.initialize();
+
+    // The synchronized schema represents the current entity graph. Removing
+    // only this feature's tables recreates the relevant pre-UNI2-29 state.
+    await schemaDataSource.query(
+      `DROP TABLE "${schema}"."task_status_history"`,
+    );
+    await schemaDataSource.query(`DROP TABLE "${schema}"."task_comments"`);
+  });
+
+  afterAll(async () => {
+    if (schemaDataSource?.isInitialized) {
+      await schemaDataSource.destroy();
+    }
+    if (adminDataSource?.isInitialized) {
+      await adminDataSource.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await adminDataSource.destroy();
+    }
+  });
+
+  it('applies and reverts tables, shared enums, foreign keys, and indexes', async () => {
+    const queryRunner = schemaDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.query(`SET search_path TO "${schema}"`);
+    const migration = new AddTaskCollaboration1787788800002();
+
+    try {
+      await migration.up(queryRunner);
+
+      const tables = (await queryRunner.query(
+        `SELECT table_name
+         FROM information_schema.tables
+         WHERE table_schema = $1
+           AND table_name IN ('task_comments', 'task_status_history')
+         ORDER BY table_name`,
+        [schema],
+      )) as { table_name: string }[];
+      expect(tables.map(({ table_name }) => table_name)).toEqual([
+        'task_comments',
+        'task_status_history',
+      ]);
+
+      const enumColumns = (await queryRunner.query(
+        `SELECT column_name, udt_name
+         FROM information_schema.columns
+         WHERE table_schema = $1
+           AND table_name = 'task_status_history'
+           AND column_name IN ('previous_status', 'new_status')
+         ORDER BY column_name`,
+        [schema],
+      )) as { column_name: string; udt_name: string }[];
+      expect(enumColumns).toEqual([
+        { column_name: 'new_status', udt_name: 'tasks_status_enum' },
+        { column_name: 'previous_status', udt_name: 'tasks_status_enum' },
+      ]);
+
+      const foreignKeys = (await queryRunner.query(
+        `SELECT COUNT(*)::int AS count
+         FROM pg_constraint constraint_record
+         JOIN pg_class table_record ON table_record.oid = constraint_record.conrelid
+         JOIN pg_namespace namespace_record ON namespace_record.oid = table_record.relnamespace
+         WHERE namespace_record.nspname = $1
+           AND table_record.relname IN ('task_comments', 'task_status_history')
+           AND constraint_record.contype = 'f'`,
+        [schema],
+      )) as { count: number }[];
+      expect(Number(foreignKeys[0]?.count)).toBe(4);
+
+      const indexes = (await queryRunner.query(
+        `SELECT indexname
+         FROM pg_indexes
+         WHERE schemaname = $1
+           AND indexname IN (
+             'IDX_task_comments_task_created',
+             'IDX_task_status_history_task_created'
+           )
+         ORDER BY indexname`,
+        [schema],
+      )) as { indexname: string }[];
+      expect(indexes.map(({ indexname }) => indexname)).toEqual([
+        'IDX_task_comments_task_created',
+        'IDX_task_status_history_task_created',
+      ]);
+
+      await migration.down(queryRunner);
+
+      const collaborationTables = (await queryRunner.query(
+        `SELECT COUNT(*)::int AS count
+         FROM information_schema.tables
+         WHERE table_schema = $1
+           AND table_name IN ('task_comments', 'task_status_history')`,
+        [schema],
+      )) as { count: number }[];
+      expect(Number(collaborationTables[0]?.count)).toBe(0);
+
+      const baseTables = (await queryRunner.query(
+        `SELECT COUNT(*)::int AS count
+         FROM information_schema.tables
+         WHERE table_schema = $1
+           AND table_name IN ('members', 'tasks')`,
+        [schema],
+      )) as { count: number }[];
+      expect(Number(baseTables[0]?.count)).toBe(2);
+    } finally {
+      await queryRunner.release();
+    }
+  });
+});

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src next.config.ts postcss.config.mjs",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/project-experience.test.js .test-dist/app/task-collaboration.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/project-experience.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
@@ -17,11 +17,14 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/react": "^16.3.2",
+    "@types/jsdom": "^28.0.3",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "jsdom": "^30.0.1",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src next.config.ts postcss.config.mjs",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/project-experience.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/project-experience.test.js .test-dist/app/task-collaboration.test.js",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/frontend/src/app/task-collaboration.test.ts
+++ b/apps/frontend/src/app/task-collaboration.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { appendTaskComment, TaskCommentItem } from './task-collaboration';
+import {
+  appendCommentToMatchingTask,
+  appendTaskComment,
+  TaskCommentItem,
+} from './task-collaboration';
 
 const comment = (
   id: number,
@@ -34,5 +38,15 @@ describe('task collaboration helpers', () => {
     );
 
     assert.deepEqual(result.map(({ id }) => id), [1, 2]);
+  });
+
+  it('ignores a late response from a different task', () => {
+    const currentTask = { id: 11, comments: [] };
+    const lateComment = comment(2, '2026-08-03T12:01:00.000Z');
+
+    const result = appendCommentToMatchingTask(currentTask, lateComment);
+
+    assert.equal(result, currentTask);
+    assert.deepEqual(currentTask.comments, []);
   });
 });

--- a/apps/frontend/src/app/task-collaboration.test.ts
+++ b/apps/frontend/src/app/task-collaboration.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { appendTaskComment, TaskCommentItem } from './task-collaboration';
+
+const comment = (
+  id: number,
+  createdAt: string,
+  content = `Comentario ${id}`,
+): TaskCommentItem => ({
+  id,
+  taskId: 10,
+  authorId: 3,
+  author: { id: 3, firstNames: 'Ana', lastNames: 'Torres' },
+  content,
+  createdAt,
+});
+
+describe('task collaboration helpers', () => {
+  it('appends a created comment without mutating the server snapshot', () => {
+    const current = [comment(1, '2026-08-03T12:00:00.000Z')];
+    const result = appendTaskComment(
+      current,
+      comment(2, '2026-08-03T12:01:00.000Z'),
+    );
+
+    assert.deepEqual(result.map(({ id }) => id), [1, 2]);
+    assert.deepEqual(current.map(({ id }) => id), [1]);
+  });
+
+  it('keeps comments in chronological order', () => {
+    const result = appendTaskComment(
+      [comment(2, '2026-08-03T12:01:00.000Z')],
+      comment(1, '2026-08-03T12:00:00.000Z'),
+    );
+
+    assert.deepEqual(result.map(({ id }) => id), [1, 2]);
+  });
+});

--- a/apps/frontend/src/app/task-collaboration.ts
+++ b/apps/frontend/src/app/task-collaboration.ts
@@ -1,0 +1,32 @@
+export type CollaborationMember = {
+  id: number;
+  firstNames: string;
+  lastNames: string;
+};
+
+export type TaskCommentItem = {
+  id: number;
+  taskId: number;
+  authorId: number;
+  author: CollaborationMember;
+  content: string;
+  createdAt: string;
+};
+
+export function appendTaskComment(
+  comments: TaskCommentItem[],
+  comment: TaskCommentItem,
+): TaskCommentItem[] {
+  return [...comments, comment].sort((left, right) => {
+    const timestampDifference =
+      Date.parse(left.createdAt) - Date.parse(right.createdAt);
+    return timestampDifference || left.id - right.id;
+  });
+}
+
+export function formatCollaborationTimestamp(value: string): string {
+  return new Intl.DateTimeFormat('es-PE', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}

--- a/apps/frontend/src/app/task-collaboration.ts
+++ b/apps/frontend/src/app/task-collaboration.ts
@@ -24,6 +24,19 @@ export function appendTaskComment(
   });
 }
 
+export function appendCommentToMatchingTask<
+  T extends { id: number; comments?: TaskCommentItem[] },
+>(task: T | null, comment: TaskCommentItem): T | null {
+  if (!task || task.id !== comment.taskId) {
+    return task;
+  }
+
+  return {
+    ...task,
+    comments: appendTaskComment(task.comments ?? [], comment),
+  };
+}
+
 export function formatCollaborationTimestamp(value: string): string {
   return new Intl.DateTimeFormat('es-PE', {
     dateStyle: 'medium',

--- a/apps/frontend/src/app/task-management.test.tsx
+++ b/apps/frontend/src/app/task-management.test.tsx
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { JSDOM } from "jsdom";
+import type { Task } from "./task-management";
+
+type FetchCall = {
+  method: string;
+  pathname: string;
+  body?: unknown;
+};
+
+const jsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("TaskManagement collaboration flow", () => {
+  let dom: JSDOM;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    dom = new JSDOM("<!doctype html><html><body></body></html>", {
+      url: "http://localhost",
+    });
+    Object.defineProperties(globalThis, {
+      window: { configurable: true, value: dom.window },
+      document: { configurable: true, value: dom.window.document },
+      navigator: { configurable: true, value: dom.window.navigator },
+      HTMLElement: { configurable: true, value: dom.window.HTMLElement },
+      MutationObserver: {
+        configurable: true,
+        value: dom.window.MutationObserver,
+      },
+    });
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    dom.window.close();
+  });
+
+  it("loads collaboration, posts a comment, and refreshes history after a status change", async () => {
+    const [{ cleanup, fireEvent, render, waitFor }, { default: TaskManagement }] =
+      await Promise.all([
+        import("@testing-library/react"),
+        import("./task-management"),
+      ]);
+    const calls: FetchCall[] = [];
+    const member = {
+      id: 1,
+      firstNames: "Ana",
+      lastNames: "Torres",
+      major: "Ingeniería de Sistemas",
+      role: "presidencia",
+    };
+    const project = {
+      id: 1,
+      name: "Portal de miembros",
+      description: null,
+      startDate: null,
+      endDate: null,
+      status: "active" as const,
+      isArchived: false,
+      phases: [],
+      memberships: [
+        { id: 1, memberId: member.id, role: "representative" as const, member },
+      ],
+    };
+    const baseTask = {
+      id: 10,
+      title: "Implementar colaboración",
+      description: "Detalle de la tarea",
+      status: "in_progress" as const,
+      priority: "high" as const,
+      dueDate: null,
+      projectId: project.id,
+      phaseId: null,
+      assignees: [],
+      createdAt: "2026-08-03T10:00:00.000Z",
+    };
+    let detail: Task = {
+      ...baseTask,
+      comments: [
+        {
+          id: 1,
+          taskId: baseTask.id,
+          authorId: member.id,
+          author: member,
+          content: "Primer comentario",
+          createdAt: "2026-08-03T10:01:00.000Z",
+        },
+      ],
+      statusHistory: [
+        {
+          id: 1,
+          taskId: baseTask.id,
+          previousStatus: "todo" as const,
+          newStatus: "in_progress" as const,
+          actorId: member.id,
+          actor: member,
+          createdAt: "2026-08-03T10:02:00.000Z",
+        },
+      ],
+    };
+
+    globalThis.fetch = async (input, init) => {
+      const requestUrl = new URL(
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url,
+      );
+      const method = init?.method ?? "GET";
+      const body =
+        typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+      calls.push({ method, pathname: requestUrl.pathname, body });
+
+      if (requestUrl.pathname === "/projects/1") {
+        return jsonResponse(project);
+      }
+      if (requestUrl.pathname === "/tasks" && method === "GET") {
+        return jsonResponse({
+          data: [{ ...baseTask, status: detail.status }],
+          meta: { total: 1, page: 1, limit: 10, lastPage: 1 },
+        });
+      }
+      if (requestUrl.pathname === "/tasks/10/comments" && method === "POST") {
+        return jsonResponse(
+          {
+            id: 2,
+            taskId: baseTask.id,
+            authorId: member.id,
+            author: member,
+            content: (body as { content: string }).content,
+            createdAt: "2026-08-03T10:03:00.000Z",
+          },
+          201,
+        );
+      }
+      if (requestUrl.pathname === "/tasks/10/status" && method === "PATCH") {
+        detail = {
+          ...detail,
+          status: "in_review",
+          statusHistory: [
+            {
+              id: 2,
+              taskId: baseTask.id,
+              previousStatus: "in_progress",
+              newStatus: "in_review",
+              actorId: member.id,
+              actor: member,
+              createdAt: "2026-08-03T10:04:00.000Z",
+            },
+            ...(detail.statusHistory ?? []),
+          ],
+        };
+        return jsonResponse(detail);
+      }
+      if (requestUrl.pathname === "/tasks/10") {
+        return jsonResponse(detail);
+      }
+
+      return jsonResponse({ message: "Unexpected request" }, 500);
+    };
+
+    const view = render(
+      <TaskManagement
+        projects={[project]}
+        accessToken="mock-token"
+        apiUrl="http://api.test"
+        currentMember={member}
+      />,
+    );
+
+    try {
+      fireEvent.click(
+        await view.findByRole("button", { name: "Implementar colaboración" }),
+      );
+      await view.findByText("Primer comentario");
+      await waitFor(() =>
+        assert.match(
+          view.container.textContent ?? "",
+          /cambió de Por hacer a En progreso/,
+        ),
+      );
+
+      fireEvent.change(
+        view.getByPlaceholderText("Escribe una actualización o pregunta..."),
+        { target: { value: "Listo para revisar" } },
+      );
+      fireEvent.click(
+        view.getByRole("button", { name: "Agregar comentario" }),
+      );
+
+      await view.findByText("Listo para revisar");
+      assert.equal(
+        calls.some(
+          ({ method, pathname, body }) =>
+            method === "POST" &&
+            pathname === "/tasks/10/comments" &&
+            (body as { content?: string })?.content === "Listo para revisar",
+        ),
+        true,
+      );
+
+      fireEvent.click(view.getByRole("button", { name: "En revisión" }));
+      await waitFor(() =>
+        assert.match(
+          view.container.textContent ?? "",
+          /cambió de En progreso a En revisión/,
+        ),
+      );
+      assert.equal(
+        calls.some(
+          ({ method, pathname }) =>
+            method === "PATCH" && pathname === "/tasks/10/status",
+        ),
+        true,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/apps/frontend/src/app/task-management.tsx
+++ b/apps/frontend/src/app/task-management.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  appendTaskComment,
+  CollaborationMember,
+  formatCollaborationTimestamp,
+  TaskCommentItem,
+} from "./task-collaboration";
 
 type Area = {
   id: number;
@@ -101,8 +107,20 @@ export type Task = {
   phaseId: number | null;
   phase?: ProjectPhase | null;
   assignees?: TaskAssignee[];
+  comments?: TaskCommentItem[];
+  statusHistory?: TaskStatusHistoryItem[];
   createdAt?: string;
   updatedAt?: string;
+};
+
+type TaskStatusHistoryItem = {
+  id: number;
+  taskId: number;
+  previousStatus: TaskStatus;
+  newStatus: TaskStatus;
+  actorId: number;
+  actor: CollaborationMember;
+  createdAt: string;
 };
 
 export type PaginatedResponse<T> = {
@@ -201,7 +219,9 @@ function getMemberAreaIds(member: Member): number[] {
   return [...ids];
 }
 
-function memberName(member: Member): string {
+function memberName(
+  member: Pick<Member, "firstNames" | "lastNames">,
+): string {
   return `${member.firstNames} ${member.lastNames}`.trim();
 }
 
@@ -319,6 +339,8 @@ export default function TaskManagement({
   const [tasksLoading, setTasksLoading] = useState(false);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
+  const [commentContent, setCommentContent] = useState("");
+  const [commentSubmitting, setCommentSubmitting] = useState(false);
 
   // Filters state
   const [statusFilter, setStatusFilter] = useState("");
@@ -655,6 +677,47 @@ export default function TaskManagement({
       );
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleCommentSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!taskDetail || !commentContent.trim()) return;
+
+    setCommentSubmitting(true);
+    setError("");
+    setNotice("");
+    try {
+      const createdComment = await requestJson<TaskCommentItem>(
+        apiUrl,
+        accessToken,
+        `/tasks/${taskDetail.id}/comments`,
+        {
+          method: "POST",
+          body: JSON.stringify({ content: commentContent }),
+        },
+      );
+      setTaskDetail((current) =>
+        current
+          ? {
+              ...current,
+              comments: appendTaskComment(
+                current.comments ?? [],
+                createdComment,
+              ),
+            }
+          : current,
+      );
+      setCommentContent("");
+      setNotice("Comentario agregado");
+    } catch (currentError) {
+      setError(
+        currentError instanceof Error
+          ? currentError.message
+          : "No se pudo agregar el comentario",
+      );
+    } finally {
+      setCommentSubmitting(false);
     }
   };
 
@@ -1327,6 +1390,71 @@ export default function TaskManagement({
                 </p>
               </div>
 
+              <div className="rounded-md border border-[#1e1f2e] bg-[#0c0d16] p-6 space-y-5">
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="text-xs font-bold uppercase tracking-wider text-zinc-500">
+                    Comentarios
+                  </h3>
+                  <span className="text-xs text-zinc-600">
+                    {taskDetail.comments?.length ?? 0}
+                  </span>
+                </div>
+
+                <div className="space-y-3">
+                  {taskDetail.comments?.length ? (
+                    taskDetail.comments.map((comment) => (
+                      <article
+                        key={comment.id}
+                        className="rounded border border-[#1e1f2e]/60 bg-[#151522]/55 p-4"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <span className="text-sm font-semibold text-zinc-200">
+                            {memberName(comment.author)}
+                          </span>
+                          <time className="text-[11px] text-zinc-600">
+                            {formatCollaborationTimestamp(comment.createdAt)}
+                          </time>
+                        </div>
+                        <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-zinc-300">
+                          {comment.content}
+                        </p>
+                      </article>
+                    ))
+                  ) : (
+                    <p className="text-sm text-zinc-500">
+                      Aún no hay comentarios en esta tarea.
+                    </p>
+                  )}
+                </div>
+
+                <form
+                  className="space-y-3 border-t border-[#1e1f2e]/50 pt-4"
+                  onSubmit={handleCommentSubmit}
+                >
+                  <label className="block">
+                    <span className="sr-only">Agregar comentario</span>
+                    <textarea
+                      value={commentContent}
+                      onChange={(event) => setCommentContent(event.target.value)}
+                      maxLength={2000}
+                      rows={3}
+                      required
+                      placeholder="Escribe una actualización o pregunta..."
+                      className="w-full rounded bg-[#151522] border border-[#1e1f2e]/80 p-3 text-sm text-white placeholder-zinc-500 outline-none focus:border-[#4067c9]"
+                    />
+                  </label>
+                  <div className="flex justify-end">
+                    <button
+                      type="submit"
+                      disabled={commentSubmitting || !commentContent.trim()}
+                      className="rounded bg-[#4067c9] px-4 py-2 text-xs font-bold text-white transition hover:bg-[#5278d5] disabled:opacity-50"
+                    >
+                      {commentSubmitting ? "Publicando..." : "Agregar comentario"}
+                    </button>
+                  </div>
+                </form>
+              </div>
+
               {/* Dropdowns fields card exactly as Figma */}
               <div className="rounded-md border border-[#1e1f2e] bg-[#0c0d16] p-6">
                 <div className="grid gap-4 md:grid-cols-3">
@@ -1414,6 +1542,37 @@ export default function TaskManagement({
                     + Asignar responsables
                   </button>
                 )}
+              </div>
+
+              <div className="rounded-md border border-[#1e1f2e] bg-[#0c0d16] p-6 space-y-4">
+                <h3 className="text-xs font-bold uppercase tracking-wider text-zinc-500">
+                  Historial de estado
+                </h3>
+                <ol className="space-y-4">
+                  {taskDetail.statusHistory?.length ? (
+                    taskDetail.statusHistory.map((entry) => (
+                      <li
+                        key={entry.id}
+                        className="border-l border-[#4067c9]/40 pl-4"
+                      >
+                        <p className="text-xs leading-5 text-zinc-300">
+                          <span className="font-semibold text-zinc-100">
+                            {memberName(entry.actor)}
+                          </span>{" "}
+                          cambió de {STATUS_INFO[entry.previousStatus].label} a{" "}
+                          {STATUS_INFO[entry.newStatus].label}.
+                        </p>
+                        <time className="mt-1 block text-[11px] text-zinc-600">
+                          {formatCollaborationTimestamp(entry.createdAt)}
+                        </time>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-xs text-zinc-500">
+                      Aún no hay cambios de estado.
+                    </li>
+                  )}
+                </ol>
               </div>
 
               {/* State pills transition switcher card */}

--- a/apps/frontend/src/app/task-management.tsx
+++ b/apps/frontend/src/app/task-management.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import {
-  appendTaskComment,
+  appendCommentToMatchingTask,
   CollaborationMember,
   formatCollaborationTimestamp,
   TaskCommentItem,
@@ -339,8 +339,11 @@ export default function TaskManagement({
   const [tasksLoading, setTasksLoading] = useState(false);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
-  const [commentContent, setCommentContent] = useState("");
+  const [commentDrafts, setCommentDrafts] = useState<Record<number, string>>(
+    {},
+  );
   const [commentSubmitting, setCommentSubmitting] = useState(false);
+  const commentContent = taskDetail ? (commentDrafts[taskDetail.id] ?? "") : "";
 
   // Filters state
   const [statusFilter, setStatusFilter] = useState("");
@@ -647,6 +650,7 @@ export default function TaskManagement({
   // Status transitions
   const handleTransition = async (nextStatus: TaskStatus) => {
     if (!taskDetail || nextStatus === taskDetail.status) return;
+    const taskId = taskDetail.id;
     setLoading(true);
     setError("");
     setNotice("");
@@ -654,7 +658,7 @@ export default function TaskManagement({
       await requestJson<Task>(
         apiUrl,
         accessToken,
-        `/tasks/${taskDetail.id}/status`,
+        `/tasks/${taskId}/status`,
         {
           method: "PATCH",
           body: JSON.stringify({ status: nextStatus }),
@@ -666,9 +670,11 @@ export default function TaskManagement({
       const detail = await requestJson<Task>(
         apiUrl,
         accessToken,
-        `/tasks/${taskDetail.id}`,
+        `/tasks/${taskId}`,
       );
-      setTaskDetail(detail);
+      setTaskDetail((current) =>
+        current?.id === detail.id ? detail : current,
+      );
     } catch (currentError) {
       setError(
         currentError instanceof Error
@@ -683,6 +689,8 @@ export default function TaskManagement({
   const handleCommentSubmit = async (event: FormEvent) => {
     event.preventDefault();
     if (!taskDetail || !commentContent.trim()) return;
+    const submittedTaskId = taskDetail.id;
+    const submittedContent = commentContent.trim();
 
     setCommentSubmitting(true);
     setError("");
@@ -691,24 +699,23 @@ export default function TaskManagement({
       const createdComment = await requestJson<TaskCommentItem>(
         apiUrl,
         accessToken,
-        `/tasks/${taskDetail.id}/comments`,
+        `/tasks/${submittedTaskId}/comments`,
         {
           method: "POST",
-          body: JSON.stringify({ content: commentContent }),
+          body: JSON.stringify({ content: submittedContent }),
         },
       );
       setTaskDetail((current) =>
-        current
-          ? {
-              ...current,
-              comments: appendTaskComment(
-                current.comments ?? [],
-                createdComment,
-              ),
-            }
-          : current,
+        appendCommentToMatchingTask(current, createdComment),
       );
-      setCommentContent("");
+      setCommentDrafts((current) => {
+        if (current[submittedTaskId]?.trim() !== submittedContent) {
+          return current;
+        }
+        const next = { ...current };
+        delete next[submittedTaskId];
+        return next;
+      });
       setNotice("Comentario agregado");
     } catch (currentError) {
       setError(
@@ -1435,7 +1442,12 @@ export default function TaskManagement({
                     <span className="sr-only">Agregar comentario</span>
                     <textarea
                       value={commentContent}
-                      onChange={(event) => setCommentContent(event.target.value)}
+                      onChange={(event) =>
+                        setCommentDrafts((current) => ({
+                          ...current,
+                          [taskDetail.id]: event.target.value,
+                        }))
+                      }
                       maxLength={2000}
                       rows={3}
                       required

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -15,6 +15,8 @@
     "src/app/login/login-validation.test.ts",
     "src/app/project-experience.ts",
     "src/app/project-experience.test.ts",
+    "src/app/task-collaboration.ts",
+    "src/app/task-collaboration.test.ts",
     "src/lib/auth-client.ts"
   ]
 }

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -17,6 +17,8 @@
     "src/app/project-experience.test.ts",
     "src/app/task-collaboration.ts",
     "src/app/task-collaboration.test.ts",
+    "src/app/task-management.tsx",
+    "src/app/task-management.test.tsx",
     "src/lib/auth-client.ts"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2222,13 +2222,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "apps/backend/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "apps/backend/node_modules/ansis": {
       "version": "4.2.0",
       "license": "ISC",
@@ -4888,14 +4881,6 @@
         "node": ">=0.10.0"
       }
     },
-    "apps/backend/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "apps/backend/node_modules/resolve-cwd": {
       "version": "3.0.0",
       "dev": true,
@@ -6007,11 +5992,14 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@testing-library/react": "^16.3.2",
+        "@types/jsdom": "^28.0.3",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "jsdom": "^30.0.1",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -6027,6 +6015,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+      "integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-color-parser": "^4.1.9",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6221,6 +6262,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -6277,6 +6328,159 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -6454,6 +6658,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -7609,6 +7831,66 @@
         "tailwindcss": "4.2.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -7643,10 +7925,38 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
+      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.29.0.tgz",
+      "integrity": "sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7693,6 +8003,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/validator": {
       "version": "13.15.10",
@@ -8304,6 +8621,15 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -8579,6 +8905,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -8800,6 +9136,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -8813,6 +9163,35 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -8891,6 +9270,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -8933,6 +9319,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -8955,6 +9352,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -9023,6 +9428,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -10110,6 +10528,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -10457,6 +10888,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -10668,6 +11106,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -11115,6 +11604,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -11133,6 +11633,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -11537,6 +12044,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11758,6 +12278,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -11877,6 +12435,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -12037,6 +12605,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -12530,6 +13111,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -12599,6 +13187,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -12642,6 +13250,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -12860,6 +13494,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -12963,6 +13607,54 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -13077,6 +13769,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",


### PR DESCRIPTION
## Summary

Implements task collaboration and immutable status tracking for UNI2-29.

## Changes

- Add `task_comments` persistence with:
  - task reference
  - author
  - content
  - creation timestamp
- Add immutable `task_status_history` persistence with:
  - previous status
  - new status
  - actor
  - creation timestamp
- Record status history atomically within the existing status transition transaction.
- Add protected endpoints to:
  - create task comments
  - list task comments
  - list task status history
- Include comments and status history in task detail responses.
- Restrict collaboration data using the existing authenticated project-scoped access rules.
- Add comments and status history sections to the task detail UI.
- Add DTO validation, migration coverage, service/controller tests, and frontend collaboration checks.

## API

- `POST /tasks/:id/comments`
- `GET /tasks/:id/comments`
- `GET /tasks/:id/status-history`

Status history has no public create, update, or delete endpoint.

## Verification

- Backend: 30 suites, 261 tests passing
- Frontend: 4 suites, 15 checks passing
- Backend and frontend lint passing
- Backend and frontend type-check passing
- Backend and frontend production builds passing

## Notes

Database-backed e2e tests were not executed locally because `apps/backend/.env` is not configured.