### PR TITLE
feat(audit): register and display basic audit events for key v1 actions

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { ProjectsModule } from './projects/projects.module';
 import { MigrateMemberRolesAndAreas1787788800000 } from './migrations/1787788800000-MigrateMemberRolesAndAreas';
 import { RepairMemberAreaMemberships1787788800001 } from './migrations/1787788800001-RepairMemberAreaMemberships';
 import { AddTaskCollaboration1787788800002 } from './migrations/1787788800002-AddTaskCollaboration';
+import { CreateAuditEventsTable1787788800003 } from './migrations/1787788800003-CreateAuditEventsTable';
 import { AuthModule } from './auth/auth.module';
 import { TasksModule } from './tasks/tasks.module';
 import { AuditModule } from './audit/audit.module';
@@ -40,6 +41,7 @@ import { AuditModule } from './audit/audit.module';
             MigrateMemberRolesAndAreas1787788800000,
             RepairMemberAreaMemberships1787788800001,
             AddTaskCollaboration1787788800002,
+            CreateAuditEventsTable1787788800003,
           ],
           migrationsRun: true,
         };

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { RepairMemberAreaMemberships1787788800001 } from './migrations/178778880
 import { AddTaskCollaboration1787788800002 } from './migrations/1787788800002-AddTaskCollaboration';
 import { AuthModule } from './auth/auth.module';
 import { TasksModule } from './tasks/tasks.module';
+import { AuditModule } from './audit/audit.module';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { TasksModule } from './tasks/tasks.module';
     ProjectsModule,
     AuthModule,
     TasksModule,
+    AuditModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/area/area.controller.spec.ts
+++ b/apps/backend/src/area/area.controller.spec.ts
@@ -71,9 +71,12 @@ describe('AreaController', () => {
       };
       mockAreaService.create.mockResolvedValue(expectedResult as any);
 
-      const result = await controller.create(createAreaDto);
+      const result = await controller.create(createAreaDto, undefined);
       expect(result).toEqual(expectedResult);
-      expect(mockAreaService.create).toHaveBeenCalledWith(createAreaDto);
+      expect(mockAreaService.create).toHaveBeenCalledWith(
+        createAreaDto,
+        undefined,
+      );
     });
   });
 
@@ -124,9 +127,13 @@ describe('AreaController', () => {
       const expectedResult = { id: 1, ...updateAreaDto };
       mockAreaService.update.mockResolvedValue(expectedResult as any);
 
-      const result = await controller.update(1, updateAreaDto);
+      const result = await controller.update(1, updateAreaDto, undefined);
       expect(result).toEqual(expectedResult);
-      expect(mockAreaService.update).toHaveBeenCalledWith(1, updateAreaDto);
+      expect(mockAreaService.update).toHaveBeenCalledWith(
+        1,
+        updateAreaDto,
+        undefined,
+      );
     });
   });
 
@@ -135,9 +142,17 @@ describe('AreaController', () => {
       const expectedResult = { id: 1, name: 'Area 1', isArchived: true };
       mockAreaService.archive.mockResolvedValue(expectedResult as any);
 
-      const result = await controller.archive(1, { confirmName: 'Area 1' });
+      const result = await controller.archive(
+        1,
+        { confirmName: 'Area 1' },
+        undefined,
+      );
       expect(result).toEqual(expectedResult);
-      expect(mockAreaService.archive).toHaveBeenCalledWith(1, 'Area 1');
+      expect(mockAreaService.archive).toHaveBeenCalledWith(
+        1,
+        'Area 1',
+        undefined,
+      );
     });
   });
 

--- a/apps/backend/src/area/area.controller.spec.ts
+++ b/apps/backend/src/area/area.controller.spec.ts
@@ -5,6 +5,7 @@ import { ACCESS_SCOPE_KEY } from '../common/decorators/access-scope.decorator';
 import { ROLES_KEY } from '../common/decorators/roles.decorator';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { RolesGuard } from '../common/guards/roles.guard';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { AreaController } from './area.controller';
 import { AreaService } from './area.service';
 
@@ -71,7 +72,10 @@ describe('AreaController', () => {
       };
       mockAreaService.create.mockResolvedValue(expectedResult as any);
 
-      const result = await controller.create(createAreaDto, undefined);
+      const result = await controller.create(
+        createAreaDto,
+        undefined as unknown as RequestAccessActor,
+      );
       expect(result).toEqual(expectedResult);
       expect(mockAreaService.create).toHaveBeenCalledWith(
         createAreaDto,
@@ -127,7 +131,11 @@ describe('AreaController', () => {
       const expectedResult = { id: 1, ...updateAreaDto };
       mockAreaService.update.mockResolvedValue(expectedResult as any);
 
-      const result = await controller.update(1, updateAreaDto, undefined);
+      const result = await controller.update(
+        1,
+        updateAreaDto,
+        undefined as unknown as RequestAccessActor,
+      );
       expect(result).toEqual(expectedResult);
       expect(mockAreaService.update).toHaveBeenCalledWith(
         1,
@@ -145,7 +153,7 @@ describe('AreaController', () => {
       const result = await controller.archive(
         1,
         { confirmName: 'Area 1' },
-        undefined,
+        undefined as unknown as RequestAccessActor,
       );
       expect(result).toEqual(expectedResult);
       expect(mockAreaService.archive).toHaveBeenCalledWith(

--- a/apps/backend/src/area/area.controller.ts
+++ b/apps/backend/src/area/area.controller.ts
@@ -29,7 +29,7 @@ export class AreaController {
   @Roles(AreaRole.PRESIDENCIA)
   create(
     @Body() createAreaDto: CreateAreaDto,
-    @CurrentAccessActor() accessActor: RequestAccessActor,
+    @CurrentAccessActor() accessActor?: RequestAccessActor,
   ) {
     return this.areaService.create(createAreaDto, accessActor);
   }
@@ -60,7 +60,7 @@ export class AreaController {
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateAreaDto: UpdateAreaDto,
-    @CurrentAccessActor() accessActor: RequestAccessActor,
+    @CurrentAccessActor() accessActor?: RequestAccessActor,
   ) {
     return this.areaService.update(id, updateAreaDto, accessActor);
   }
@@ -70,7 +70,7 @@ export class AreaController {
   archive(
     @Param('id', ParseIntPipe) id: number,
     @Body() confirmNameDto: ConfirmNameDto,
-    @CurrentAccessActor() accessActor: RequestAccessActor,
+    @CurrentAccessActor() accessActor?: RequestAccessActor,
   ) {
     return this.areaService.archive(
       id,

--- a/apps/backend/src/area/area.controller.ts
+++ b/apps/backend/src/area/area.controller.ts
@@ -27,8 +27,11 @@ export class AreaController {
 
   @Post()
   @Roles(AreaRole.PRESIDENCIA)
-  create(@Body() createAreaDto: CreateAreaDto) {
-    return this.areaService.create(createAreaDto);
+  create(
+    @Body() createAreaDto: CreateAreaDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ) {
+    return this.areaService.create(createAreaDto, accessActor);
   }
 
   @Get()
@@ -57,8 +60,9 @@ export class AreaController {
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateAreaDto: UpdateAreaDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ) {
-    return this.areaService.update(id, updateAreaDto);
+    return this.areaService.update(id, updateAreaDto, accessActor);
   }
 
   @Patch(':id/archive')
@@ -66,7 +70,12 @@ export class AreaController {
   archive(
     @Param('id', ParseIntPipe) id: number,
     @Body() confirmNameDto: ConfirmNameDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ) {
-    return this.areaService.archive(id, confirmNameDto.confirmName);
+    return this.areaService.archive(
+      id,
+      confirmNameDto.confirmName,
+      accessActor,
+    );
   }
 }

--- a/apps/backend/src/area/area.module.ts
+++ b/apps/backend/src/area/area.module.ts
@@ -4,9 +4,10 @@ import { AccessControlModule } from '../common/access-control.module';
 import { AreaService } from './area.service';
 import { AreaController } from './area.controller';
 import { Area } from './entities/area.entity';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
-  imports: [AccessControlModule, TypeOrmModule.forFeature([Area])],
+  imports: [AccessControlModule, TypeOrmModule.forFeature([Area]), AuditModule],
   controllers: [AreaController],
   providers: [AreaService],
   exports: [AreaService],

--- a/apps/backend/src/area/area.service.spec.ts
+++ b/apps/backend/src/area/area.service.spec.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { AreaRole } from '../common/enums/area-role.enum';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { AreaService } from './area.service';
 import { Area } from './entities/area.entity';
 import { AuditService } from '../audit/audit.service';
@@ -183,18 +184,29 @@ describe('AreaService', () => {
     expect(mockAreaRepository.save).not.toHaveBeenCalled();
   });
 
-  it('archives an area when confirmName exactly matches', async () => {
+  it('archives an area when confirmName exactly matches and records audit event', async () => {
     const area = createArea();
     const archivedArea = createArea({ isArchived: true });
+    const accessActor: RequestAccessActor = {
+      role: AreaRole.PRESIDENCIA,
+      memberId: '1',
+    };
     repository.findOne.mockResolvedValue(area);
     repository.save.mockResolvedValue(archivedArea);
 
-    await expect(service.archive(area.id, area.name)).resolves.toEqual(
-      archivedArea,
-    );
+    await expect(
+      service.archive(area.id, area.name, accessActor),
+    ).resolves.toEqual(archivedArea);
     expect(repository.save).toHaveBeenCalledWith(
       expect.objectContaining({ id: area.id, isArchived: true }),
     );
+    expect(mockAuditService.record).toHaveBeenCalledWith(accessActor, {
+      action: 'archive',
+      entityType: 'Area',
+      entityId: area.id,
+      areaId: area.id,
+      metadata: { name: area.name },
+    });
   });
 
   it('rejects area archival when confirmName does not exactly match', async () => {

--- a/apps/backend/src/area/area.service.spec.ts
+++ b/apps/backend/src/area/area.service.spec.ts
@@ -8,6 +8,7 @@ import {
 import { AreaRole } from '../common/enums/area-role.enum';
 import { AreaService } from './area.service';
 import { Area } from './entities/area.entity';
+import { AuditService } from '../audit/audit.service';
 
 const createArea = (overrides: Partial<Area> = {}): Area => ({
   id: 1,
@@ -31,6 +32,11 @@ describe('AreaService', () => {
     findOne: jest.fn(),
   };
 
+  const mockAuditService = {
+    record: jest.fn(),
+    findAll: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
@@ -39,6 +45,10 @@ describe('AreaService', () => {
         {
           provide: getRepositoryToken(Area),
           useValue: mockAreaRepository,
+        },
+        {
+          provide: AuditService,
+          useValue: mockAuditService,
         },
       ],
     }).compile();

--- a/apps/backend/src/area/area.service.ts
+++ b/apps/backend/src/area/area.service.ts
@@ -13,15 +13,20 @@ import { parseAreaId } from '../common/utils/parse-area-id.util';
 import { CreateAreaDto } from './dto/create-area.dto';
 import { UpdateAreaDto } from './dto/update-area.dto';
 import { Area } from './entities/area.entity';
+import { AuditService } from '../audit/audit.service';
 
 @Injectable()
 export class AreaService {
   constructor(
     @InjectRepository(Area)
     private readonly areaRepository: Repository<Area>,
+    private readonly auditService: AuditService,
   ) {}
 
-  async create(createAreaDto: CreateAreaDto): Promise<Area> {
+  async create(
+    createAreaDto: CreateAreaDto,
+    accessActor?: RequestAccessActor,
+  ): Promise<Area> {
     const existingArea = await this.areaRepository.findOne({
       where: { name: ILike(createAreaDto.name) },
     });
@@ -32,7 +37,19 @@ export class AreaService {
     }
 
     const area = this.areaRepository.create(createAreaDto);
-    return this.areaRepository.save(area);
+    const savedArea = await this.areaRepository.save(area);
+
+    if (accessActor) {
+      await this.auditService.record(accessActor, {
+        action: 'create',
+        entityType: 'Area',
+        entityId: savedArea.id,
+        areaId: savedArea.id,
+        metadata: { name: savedArea.name },
+      });
+    }
+
+    return savedArea;
   }
 
   async findAll(includeArchived = false): Promise<Area[]> {
@@ -52,7 +69,11 @@ export class AreaService {
     return area;
   }
 
-  async update(id: number, updateAreaDto: UpdateAreaDto): Promise<Area> {
+  async update(
+    id: number,
+    updateAreaDto: UpdateAreaDto,
+    accessActor?: RequestAccessActor,
+  ): Promise<Area> {
     const area = await this.findOne(id);
 
     if (updateAreaDto.name) {
@@ -70,10 +91,26 @@ export class AreaService {
     // Merge the updates into the existing area
     Object.assign(area, updateAreaDto);
 
-    return this.areaRepository.save(area);
+    const savedArea = await this.areaRepository.save(area);
+
+    if (accessActor) {
+      await this.auditService.record(accessActor, {
+        action: 'update',
+        entityType: 'Area',
+        entityId: savedArea.id,
+        areaId: savedArea.id,
+        metadata: { name: savedArea.name },
+      });
+    }
+
+    return savedArea;
   }
 
-  async archive(id: number, confirmName: string): Promise<Area> {
+  async archive(
+    id: number,
+    confirmName: string,
+    accessActor?: RequestAccessActor,
+  ): Promise<Area> {
     const area = await this.findOne(id);
 
     if (confirmName !== area.name) {
@@ -83,7 +120,19 @@ export class AreaService {
     }
 
     area.isArchived = true;
-    return this.areaRepository.save(area);
+    const savedArea = await this.areaRepository.save(area);
+
+    if (accessActor) {
+      await this.auditService.record(accessActor, {
+        action: 'archive',
+        entityType: 'Area',
+        entityId: savedArea.id,
+        areaId: savedArea.id,
+        metadata: { name: savedArea.name },
+      });
+    }
+
+    return savedArea;
   }
 
   async findAccessible(

--- a/apps/backend/src/audit/audit.controller.spec.ts
+++ b/apps/backend/src/audit/audit.controller.spec.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource } from 'typeorm';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
+import { AuditController } from './audit.controller';
+import { AuditService } from './audit.service';
+import { AuditEvent } from './entities/audit-event.entity';
+
+describe('AuditController', () => {
+  let controller: AuditController;
+  let service: jest.Mocked<AuditService>;
+
+  beforeEach(async () => {
+    const mockAuditService = {
+      findAll: jest.fn(),
+      record: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuditController],
+      providers: [
+        {
+          provide: AuditService,
+          useValue: mockAuditService,
+        },
+        {
+          provide: DataSource,
+          useValue: {},
+        },
+        RolesGuard,
+      ],
+    }).compile();
+
+    controller = module.get<AuditController>(AuditController);
+    service = module.get(AuditService);
+  });
+
+  it('delegates audit logs query to auditService.findAll', async () => {
+    const expectedResult = {
+      data: [
+        {
+          id: 1,
+          actorId: 5,
+          actorName: 'Juan Pérez',
+          actorRole: AreaRole.PRESIDENCIA,
+          action: 'create',
+          entityType: 'Area',
+          entityId: '10',
+          areaId: 10,
+          timestamp: new Date(),
+          metadata: null,
+        } as AuditEvent,
+      ],
+      meta: {
+        total: 1,
+        page: 1,
+        limit: 10,
+        lastPage: 1,
+      },
+    };
+
+    const actor: RequestAccessActor = {
+      role: AreaRole.PRESIDENCIA,
+      memberId: '5',
+    };
+
+    const filterDto = { page: 1, limit: 10, action: 'create' };
+    service.findAll.mockResolvedValue(expectedResult);
+
+    const result = await controller.findAll(filterDto, actor);
+
+    expect(result).toEqual(expectedResult);
+    expect(service.findAll).toHaveBeenCalledWith(filterDto, actor);
+  });
+});

--- a/apps/backend/src/audit/audit.controller.ts
+++ b/apps/backend/src/audit/audit.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { CurrentAccessActor } from '../common/decorators/current-access-actor.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { RolesGuard } from '../common/guards/roles.guard';
+import type { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
+import { AuditService } from './audit.service';
+import { GetAuditEventsFilterDto } from './dto/get-audit-events-filter.dto';
+import { AuditEvent } from './entities/audit-event.entity';
+import { PaginatedResponse } from '../common/interfaces/paginated-response.interface';
+
+@Controller('audit')
+@UseGuards(RolesGuard)
+export class AuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  @Get()
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
+  findAll(
+    @Query() filterDto: GetAuditEventsFilterDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
+  ): Promise<PaginatedResponse<AuditEvent>> {
+    return this.auditService.findAll(filterDto, accessActor);
+  }
+}

--- a/apps/backend/src/audit/audit.module.ts
+++ b/apps/backend/src/audit/audit.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Member } from '../members/member.entity';
+import { AuditController } from './audit.controller';
+import { AuditService } from './audit.service';
+import { AuditEvent } from './entities/audit-event.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AuditEvent, Member])],
+  controllers: [AuditController],
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/apps/backend/src/audit/audit.service.spec.ts
+++ b/apps/backend/src/audit/audit.service.spec.ts
@@ -1,0 +1,226 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Between, ILike, Repository } from 'typeorm';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
+import { Member } from '../members/member.entity';
+import { AuditService } from './audit.service';
+import { AuditEvent } from './entities/audit-event.entity';
+
+describe('AuditService', () => {
+  let service: AuditService;
+  let auditRepo: jest.Mocked<Repository<AuditEvent>>;
+  let memberRepo: jest.Mocked<Repository<Member>>;
+
+  beforeEach(async () => {
+    const mockAuditRepo = {
+      create: jest.fn(
+        (dto: Partial<AuditEvent>): AuditEvent => dto as AuditEvent,
+      ),
+      save: jest.fn((event: Partial<AuditEvent>) =>
+        Promise.resolve({ id: 1, ...event } as AuditEvent),
+      ),
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+
+    const mockMemberRepo = {
+      findOne: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditService,
+        {
+          provide: getRepositoryToken(AuditEvent),
+          useValue: mockAuditRepo,
+        },
+        {
+          provide: getRepositoryToken(Member),
+          useValue: mockMemberRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuditService>(AuditService);
+    auditRepo = module.get(getRepositoryToken(AuditEvent));
+    memberRepo = module.get(getRepositoryToken(Member));
+  });
+
+  describe('record', () => {
+    const actor: RequestAccessActor = {
+      role: AreaRole.PRESIDENCIA,
+      memberId: '5',
+    };
+
+    it('records an audit event with immutable actor full name', async () => {
+      memberRepo.findOne.mockResolvedValue({
+        id: 5,
+        firstNames: 'Carlos',
+        lastNames: 'Pérez',
+      } as Member);
+
+      await service.record(actor, {
+        action: 'create',
+        entityType: 'Area',
+        entityId: 10,
+        areaId: 10,
+        metadata: { name: 'Sistemas' },
+      });
+
+      expect(memberRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 5 },
+        select: ['id', 'firstNames', 'lastNames'],
+      });
+      expect(auditRepo.create).toHaveBeenCalledWith({
+        actorId: 5,
+        actorName: 'Carlos Pérez',
+        actorRole: AreaRole.PRESIDENCIA,
+        action: 'create',
+        entityType: 'Area',
+        entityId: '10',
+        areaId: 10,
+        metadata: JSON.stringify({ name: 'Sistemas' }),
+      });
+      expect(auditRepo.save).toHaveBeenCalled();
+    });
+
+    it('skips recording if memberId is missing or invalid', async () => {
+      await service.record(
+        { role: AreaRole.PRESIDENCIA, memberId: undefined },
+        { action: 'create', entityType: 'Area', entityId: 1 },
+      );
+
+      expect(auditRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('handles repository errors silently without throwing', async () => {
+      jest.spyOn(service['logger'], 'error').mockImplementation(() => {});
+      memberRepo.findOne.mockRejectedValue(new Error('DB failure'));
+
+      await expect(
+        service.record(actor, {
+          action: 'create',
+          entityType: 'Area',
+          entityId: 1,
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('findAll', () => {
+    const presidencyActor: RequestAccessActor = {
+      role: AreaRole.PRESIDENCIA,
+      memberId: '1',
+    };
+
+    const areaDirectivaActor: RequestAccessActor = {
+      role: AreaRole.DIRECTIVA_DE_AREA,
+      areaId: '2',
+      memberId: '3',
+    };
+
+    const memberActor: RequestAccessActor = {
+      role: AreaRole.MIEMBRO,
+      memberId: '4',
+    };
+
+    it('rejects member role with ForbiddenException', async () => {
+      await expect(service.findAll({}, memberActor)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('scopes query to areaId for Directiva de Área role', async () => {
+      auditRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({}, areaDirectivaActor);
+
+      expect(auditRepo.findAndCount).toHaveBeenCalledWith({
+        where: { areaId: 2 },
+        order: { timestamp: 'DESC', id: 'DESC' },
+        skip: 0,
+        take: 10,
+      });
+    });
+
+    it('applies action, entityType (case-insensitive) and pagination filters', async () => {
+      auditRepo.findAndCount.mockResolvedValue([
+        [
+          {
+            id: 1,
+            action: 'create',
+            entityType: 'Project',
+            entityId: '100',
+          } as AuditEvent,
+        ],
+        1,
+      ]);
+
+      const result = await service.findAll(
+        {
+          page: 2,
+          limit: 5,
+          action: 'create',
+          entityType: 'project',
+        },
+        presidencyActor,
+      );
+
+      expect(auditRepo.findAndCount).toHaveBeenCalledWith({
+        where: {
+          action: 'create',
+          entityType: ILike('project'),
+        },
+        order: { timestamp: 'DESC', id: 'DESC' },
+        skip: 5,
+        take: 5,
+      });
+
+      expect(result.meta).toEqual({
+        total: 1,
+        page: 2,
+        limit: 5,
+        lastPage: 1,
+      });
+    });
+
+    it('throws BadRequestException if dateFrom is after dateTo', async () => {
+      await expect(
+        service.findAll(
+          {
+            dateFrom: '2026-08-10',
+            dateTo: '2026-08-01',
+          },
+          presidencyActor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('applies dateFrom and dateTo range filter covering full end day', async () => {
+      auditRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll(
+        {
+          dateFrom: '2026-08-01',
+          dateTo: '2026-08-05',
+        },
+        presidencyActor,
+      );
+
+      const start = new Date('2026-08-01');
+      const end = new Date('2026-08-05');
+      end.setUTCHours(23, 59, 59, 999);
+
+      expect(auditRepo.findAndCount).toHaveBeenCalledWith({
+        where: {
+          timestamp: Between(start, end),
+        },
+        order: { timestamp: 'DESC', id: 'DESC' },
+        skip: 0,
+        take: 10,
+      });
+    });
+  });
+});

--- a/apps/backend/src/audit/audit.service.ts
+++ b/apps/backend/src/audit/audit.service.ts
@@ -4,6 +4,7 @@ import {
   Between,
   EntityManager,
   FindOptionsWhere,
+  ILike,
   LessThanOrEqual,
   MoreThanOrEqual,
   Repository,
@@ -101,7 +102,7 @@ export class AuditService {
     }
 
     if (filterDto.entityType) {
-      where.entityType = filterDto.entityType;
+      where.entityType = ILike(filterDto.entityType);
     }
 
     if (filterDto.dateFrom && filterDto.dateTo) {

--- a/apps/backend/src/audit/audit.service.ts
+++ b/apps/backend/src/audit/audit.service.ts
@@ -1,0 +1,135 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  Between,
+  EntityManager,
+  FindOptionsWhere,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  Repository,
+} from 'typeorm';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
+import { parseAreaId } from '../common/utils/parse-area-id.util';
+import { Member } from '../members/member.entity';
+import { GetAuditEventsFilterDto } from './dto/get-audit-events-filter.dto';
+import { AuditEvent } from './entities/audit-event.entity';
+import { PaginatedResponse } from '../common/interfaces/paginated-response.interface';
+
+@Injectable()
+export class AuditService {
+  constructor(
+    @InjectRepository(AuditEvent)
+    private readonly auditEventsRepository: Repository<AuditEvent>,
+    @InjectRepository(Member)
+    private readonly membersRepository: Repository<Member>,
+  ) {}
+
+  async record(
+    accessActor: RequestAccessActor,
+    data: {
+      action: string;
+      entityType: string;
+      entityId: string | number;
+      areaId?: number | null;
+      metadata?: Record<string, any>;
+    },
+    entityManager?: EntityManager,
+  ): Promise<void> {
+    const actorId = Number(accessActor.memberId);
+    if (!Number.isSafeInteger(actorId) || actorId < 1) {
+      return; // Skip system/anonymous actions
+    }
+
+    const memberRepo = entityManager
+      ? entityManager.getRepository(Member)
+      : this.membersRepository;
+
+    const auditRepo = entityManager
+      ? entityManager.getRepository(AuditEvent)
+      : this.auditEventsRepository;
+
+    // Retrieve actor name to keep audit log immutable
+    const actorMember = await memberRepo.findOne({
+      where: { id: actorId },
+      select: ['id', 'firstNames', 'lastNames'],
+    });
+
+    const actorName = actorMember
+      ? `${actorMember.firstNames} ${actorMember.lastNames}`
+      : 'Unknown';
+
+    const event = auditRepo.create({
+      actorId,
+      actorName,
+      actorRole: accessActor.role,
+      action: data.action,
+      entityType: data.entityType,
+      entityId: String(data.entityId),
+      areaId: data.areaId ?? null,
+      metadata: data.metadata ? JSON.stringify(data.metadata) : null,
+    });
+
+    await auditRepo.save(event);
+  }
+
+  async findAll(
+    filterDto: GetAuditEventsFilterDto,
+    accessActor: RequestAccessActor,
+  ): Promise<PaginatedResponse<AuditEvent>> {
+    if (accessActor.role === AreaRole.MIEMBRO) {
+      throw new ForbiddenException('Members cannot access the audit screen');
+    }
+
+    const page = filterDto.page ?? 1;
+    const limit = filterDto.limit ?? 10;
+    const skip = (page - 1) * limit;
+
+    const where: FindOptionsWhere<AuditEvent> = {};
+
+    if (accessActor.role === AreaRole.DIRECTIVA_DE_AREA) {
+      const areaId = parseAreaId(accessActor.areaId);
+      where.areaId = areaId;
+    }
+
+    if (filterDto.actorId !== undefined) {
+      where.actorId = filterDto.actorId;
+    }
+
+    if (filterDto.action) {
+      where.action = filterDto.action;
+    }
+
+    if (filterDto.entityType) {
+      where.entityType = filterDto.entityType;
+    }
+
+    if (filterDto.dateFrom && filterDto.dateTo) {
+      // Set to beginning of start day and end of end day to cover full range
+      const start = new Date(filterDto.dateFrom);
+      const end = new Date(filterDto.dateTo);
+      where.timestamp = Between(start, end);
+    } else if (filterDto.dateFrom) {
+      where.timestamp = MoreThanOrEqual(new Date(filterDto.dateFrom));
+    } else if (filterDto.dateTo) {
+      where.timestamp = LessThanOrEqual(new Date(filterDto.dateTo));
+    }
+
+    const [data, total] = await this.auditEventsRepository.findAndCount({
+      where,
+      order: { timestamp: 'DESC', id: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        lastPage: Math.ceil(total / limit),
+      },
+    };
+  }
+}

--- a/apps/backend/src/audit/audit.service.ts
+++ b/apps/backend/src/audit/audit.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   Between,
@@ -19,6 +19,8 @@ import { PaginatedResponse } from '../common/interfaces/paginated-response.inter
 
 @Injectable()
 export class AuditService {
+  private readonly logger = new Logger(AuditService.name);
+
   constructor(
     @InjectRepository(AuditEvent)
     private readonly auditEventsRepository: Repository<AuditEvent>,
@@ -37,41 +39,48 @@ export class AuditService {
     },
     entityManager?: EntityManager,
   ): Promise<void> {
-    const actorId = Number(accessActor.memberId);
-    if (!Number.isSafeInteger(actorId) || actorId < 1) {
-      return; // Skip system/anonymous actions
+    try {
+      const actorId = Number(accessActor.memberId);
+      if (!Number.isSafeInteger(actorId) || actorId < 1) {
+        return; // Skip system/anonymous actions
+      }
+
+      const memberRepo = entityManager
+        ? entityManager.getRepository(Member)
+        : this.membersRepository;
+
+      const auditRepo = entityManager
+        ? entityManager.getRepository(AuditEvent)
+        : this.auditEventsRepository;
+
+      // Retrieve actor name to keep audit log immutable
+      const actorMember = await memberRepo.findOne({
+        where: { id: actorId },
+        select: ['id', 'firstNames', 'lastNames'],
+      });
+
+      const actorName = actorMember
+        ? `${actorMember.firstNames} ${actorMember.lastNames}`
+        : 'Unknown';
+
+      const event = auditRepo.create({
+        actorId,
+        actorName,
+        actorRole: accessActor.role,
+        action: data.action,
+        entityType: data.entityType,
+        entityId: String(data.entityId),
+        areaId: data.areaId ?? null,
+        metadata: data.metadata ? JSON.stringify(data.metadata) : null,
+      });
+
+      await auditRepo.save(event);
+    } catch (error) {
+      this.logger.error(
+        `Failed to record audit event for ${data.entityType}:${data.entityId} (${data.action})`,
+        error instanceof Error ? error.stack : String(error),
+      );
     }
-
-    const memberRepo = entityManager
-      ? entityManager.getRepository(Member)
-      : this.membersRepository;
-
-    const auditRepo = entityManager
-      ? entityManager.getRepository(AuditEvent)
-      : this.auditEventsRepository;
-
-    // Retrieve actor name to keep audit log immutable
-    const actorMember = await memberRepo.findOne({
-      where: { id: actorId },
-      select: ['id', 'firstNames', 'lastNames'],
-    });
-
-    const actorName = actorMember
-      ? `${actorMember.firstNames} ${actorMember.lastNames}`
-      : 'Unknown';
-
-    const event = auditRepo.create({
-      actorId,
-      actorName,
-      actorRole: accessActor.role,
-      action: data.action,
-      entityType: data.entityType,
-      entityId: String(data.entityId),
-      areaId: data.areaId ?? null,
-      metadata: data.metadata ? JSON.stringify(data.metadata) : null,
-    });
-
-    await auditRepo.save(event);
   }
 
   async findAll(

--- a/apps/backend/src/audit/audit.service.ts
+++ b/apps/backend/src/audit/audit.service.ts
@@ -1,4 +1,9 @@
-import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   Between,
@@ -119,6 +124,9 @@ export class AuditService {
       const end = new Date(filterDto.dateTo);
       if (filterDto.dateTo.length <= 10) {
         end.setUTCHours(23, 59, 59, 999);
+      }
+      if (start > end) {
+        throw new BadRequestException('dateFrom cannot be after dateTo');
       }
       where.timestamp = Between(start, end);
     } else if (filterDto.dateFrom) {

--- a/apps/backend/src/audit/audit.service.ts
+++ b/apps/backend/src/audit/audit.service.ts
@@ -106,14 +106,20 @@ export class AuditService {
     }
 
     if (filterDto.dateFrom && filterDto.dateTo) {
-      // Set to beginning of start day and end of end day to cover full range
       const start = new Date(filterDto.dateFrom);
       const end = new Date(filterDto.dateTo);
+      if (filterDto.dateTo.length <= 10) {
+        end.setUTCHours(23, 59, 59, 999);
+      }
       where.timestamp = Between(start, end);
     } else if (filterDto.dateFrom) {
       where.timestamp = MoreThanOrEqual(new Date(filterDto.dateFrom));
     } else if (filterDto.dateTo) {
-      where.timestamp = LessThanOrEqual(new Date(filterDto.dateTo));
+      const end = new Date(filterDto.dateTo);
+      if (filterDto.dateTo.length <= 10) {
+        end.setUTCHours(23, 59, 59, 999);
+      }
+      where.timestamp = LessThanOrEqual(end);
     }
 
     const [data, total] = await this.auditEventsRepository.findAndCount({

--- a/apps/backend/src/audit/dto/get-audit-events-filter.dto.ts
+++ b/apps/backend/src/audit/dto/get-audit-events-filter.dto.ts
@@ -1,5 +1,11 @@
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+import {
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 
 export class GetAuditEventsFilterDto extends PaginationDto {
@@ -18,10 +24,10 @@ export class GetAuditEventsFilterDto extends PaginationDto {
   entityType?: string;
 
   @IsOptional()
-  @IsString()
+  @IsDateString()
   dateFrom?: string;
 
   @IsOptional()
-  @IsString()
+  @IsDateString()
   dateTo?: string;
 }

--- a/apps/backend/src/audit/dto/get-audit-events-filter.dto.ts
+++ b/apps/backend/src/audit/dto/get-audit-events-filter.dto.ts
@@ -1,0 +1,27 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class GetAuditEventsFilterDto extends PaginationDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  actorId?: number;
+
+  @IsOptional()
+  @IsString()
+  action?: string;
+
+  @IsOptional()
+  @IsString()
+  entityType?: string;
+
+  @IsOptional()
+  @IsString()
+  dateFrom?: string;
+
+  @IsOptional()
+  @IsString()
+  dateTo?: string;
+}

--- a/apps/backend/src/audit/entities/audit-event.entity.ts
+++ b/apps/backend/src/audit/entities/audit-event.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('audit_events')
+export class AuditEvent {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({ name: 'actor_id', type: 'integer' })
+  actorId: number;
+
+  @Column({ name: 'actor_name', type: 'varchar', length: 255 })
+  actorName: string;
+
+  @Column({ name: 'actor_role', type: 'varchar', length: 50 })
+  actorRole: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  action: string;
+
+  @Column({ name: 'entity_type', type: 'varchar', length: 100 })
+  entityType: string;
+
+  @Column({ name: 'entity_id', type: 'varchar', length: 50 })
+  entityId: string;
+
+  @Column({ name: 'area_id', type: 'integer', nullable: true })
+  areaId: number | null;
+
+  @CreateDateColumn({ name: 'timestamp', type: 'timestamp with time zone' })
+  timestamp: Date;
+
+  @Column({ type: 'text', nullable: true })
+  metadata: string | null;
+}

--- a/apps/backend/src/auth/auth.guard.spec.ts
+++ b/apps/backend/src/auth/auth.guard.spec.ts
@@ -60,6 +60,8 @@ describe('AuthGuard', () => {
     const guard = new AuthGuard(reflector, tokenService, membersRepository);
     const member = {
       id: 7,
+      firstNames: 'Ana',
+      lastNames: 'Rojas',
       role: AreaRole.DIRECTIVA_DE_AREA,
       areaId: 3,
       activityStatus: MemberActivityStatus.ACTIVE,
@@ -85,6 +87,10 @@ describe('AuthGuard', () => {
       role: AreaRole.DIRECTIVA_DE_AREA,
       memberId: '7',
       areaId: '3',
+      member: {
+        firstNames: 'Ana',
+        lastNames: 'Rojas',
+      },
     });
     expect(request.authenticatedMember).toBe(member);
     expect(membersRepository.findOne).toHaveBeenCalledWith({

--- a/apps/backend/src/auth/auth.guard.ts
+++ b/apps/backend/src/auth/auth.guard.ts
@@ -65,6 +65,13 @@ export class AuthGuard implements CanActivate {
       role: member.role,
       memberId: String(member.id),
       areaId: member.areaId ? String(member.areaId) : undefined,
+      member:
+        member.firstNames && member.lastNames
+          ? {
+              firstNames: member.firstNames,
+              lastNames: member.lastNames,
+            }
+          : undefined,
       projectIds:
         member.role === AreaRole.MIEMBRO
           ? (member.projectMemberships ?? []).map(({ projectId }) =>

--- a/apps/backend/src/common/interfaces/request-access-actor.interface.ts
+++ b/apps/backend/src/common/interfaces/request-access-actor.interface.ts
@@ -6,4 +6,8 @@ export interface RequestAccessActor {
   memberId?: string;
   projectIds?: string[];
   status?: string;
+  member?: {
+    firstNames: string;
+    lastNames: string;
+  };
 }

--- a/apps/backend/src/members/members.controller.spec.ts
+++ b/apps/backend/src/members/members.controller.spec.ts
@@ -92,10 +92,14 @@ describe('MembersController', () => {
 
     mockMembersService.create.mockResolvedValue(createdMember);
 
-    await expect(controller.create(createMemberDto)).resolves.toEqual(
-      toMemberResponse(createdMember, AreaRole.PRESIDENCIA),
+    await expect(
+      controller.create(createMemberDto, undefined),
+    ).resolves.toEqual(toMemberResponse(createdMember, AreaRole.PRESIDENCIA));
+    expect(mockMembersService.create).toHaveBeenCalledWith(
+      createMemberDto,
+      undefined,
+      undefined,
     );
-    expect(mockMembersService.create).toHaveBeenCalledWith(createMemberDto);
   });
 
   it('lists members through the scoped service method', async () => {

--- a/apps/backend/src/members/members.controller.spec.ts
+++ b/apps/backend/src/members/members.controller.spec.ts
@@ -4,6 +4,7 @@ import { DataSource } from 'typeorm';
 import { ROLES_KEY } from '../common/decorators/roles.decorator';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { RolesGuard } from '../common/guards/roles.guard';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { MemberActivityStatus } from './enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from './enums/member-availability-status.enum';
 import { Member } from './member.entity';
@@ -93,7 +94,10 @@ describe('MembersController', () => {
     mockMembersService.create.mockResolvedValue(createdMember);
 
     await expect(
-      controller.create(createMemberDto, undefined),
+      controller.create(
+        createMemberDto,
+        undefined as unknown as RequestAccessActor,
+      ),
     ).resolves.toEqual(toMemberResponse(createdMember, AreaRole.PRESIDENCIA));
     expect(mockMembersService.create).toHaveBeenCalledWith(
       createMemberDto,

--- a/apps/backend/src/members/members.controller.ts
+++ b/apps/backend/src/members/members.controller.ts
@@ -31,7 +31,7 @@ export class MembersController {
   @Roles(AreaRole.PRESIDENCIA)
   async create(
     @Body() createMemberDto: CreateMemberDto,
-    @CurrentAccessActor() accessActor: RequestAccessActor,
+    @CurrentAccessActor() accessActor?: RequestAccessActor,
   ): Promise<MemberResponse> {
     const member = await this.membersService.create(
       createMemberDto,

--- a/apps/backend/src/members/members.controller.ts
+++ b/apps/backend/src/members/members.controller.ts
@@ -31,8 +31,13 @@ export class MembersController {
   @Roles(AreaRole.PRESIDENCIA)
   async create(
     @Body() createMemberDto: CreateMemberDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ): Promise<MemberResponse> {
-    const member = await this.membersService.create(createMemberDto);
+    const member = await this.membersService.create(
+      createMemberDto,
+      undefined,
+      accessActor,
+    );
     return toMemberResponse(member, AreaRole.PRESIDENCIA);
   }
 
@@ -50,8 +55,14 @@ export class MembersController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateMemberDto: UpdateMemberDto,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ): Promise<MemberResponse> {
-    const member = await this.membersService.update(id, updateMemberDto);
+    const member = await this.membersService.update(
+      id,
+      updateMemberDto,
+      undefined,
+      accessActor,
+    );
     return toMemberResponse(member, AreaRole.PRESIDENCIA);
   }
 

--- a/apps/backend/src/members/members.module.ts
+++ b/apps/backend/src/members/members.module.ts
@@ -7,11 +7,13 @@ import { Skill } from '../skills/skill.entity';
 import { Member } from './member.entity';
 import { MembersController } from './members.controller';
 import { MembersService } from './members.service';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [
     AccessControlModule,
     TypeOrmModule.forFeature([Member, Skill, Area, AreaMembership]),
+    AuditModule,
   ],
   controllers: [MembersController],
   providers: [MembersService],

--- a/apps/backend/src/members/members.service.spec.ts
+++ b/apps/backend/src/members/members.service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -11,6 +12,7 @@ import {
 } from 'typeorm';
 import { Area } from '../area/entities/area.entity';
 import { AreaRole } from '../common/enums/area-role.enum';
+import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { Skill } from '../skills/skill.entity';
 import { CreateMemberDto } from './dto/create-member.dto';
 import { MemberActivityStatus } from './enums/member-activity-status.enum';
@@ -55,6 +57,7 @@ const createQueryBuilderMock = (members: Member[]) => ({
 
 describe('MembersService', () => {
   let service: MembersService;
+  let auditService: jest.Mocked<AuditService>;
   let membersRepository: MemberRepositoryMock;
   let skillsRepository: SkillRepositoryMock;
   let areasRepository: AreaRepositoryMock;
@@ -168,6 +171,7 @@ describe('MembersService', () => {
     }).compile();
 
     service = module.get<MembersService>(MembersService);
+    auditService = module.get(AuditService);
     persistedSkills = [createSkill(1, 'typescript'), createSkill(2, 'testing')];
     persistedAreaDirectiveMember = {
       id: 10,
@@ -201,14 +205,27 @@ describe('MembersService', () => {
     } as Member;
   });
 
-  it('creates and persists an area directive member', async () => {
+  it('creates and persists an area directive member and records audit event', async () => {
+    const accessActor: RequestAccessActor = {
+      role: AreaRole.PRESIDENCIA,
+      memberId: '1',
+    };
     areasRepository.exists?.mockResolvedValue(true);
     skillsRepository.find?.mockResolvedValue(persistedSkills);
     membersRepository.create?.mockReturnValue(persistedAreaDirectiveMember);
     membersRepository.save?.mockResolvedValue(persistedAreaDirectiveMember);
 
-    await expect(service.create(areaDirectiveMemberDto)).resolves.toEqual(
-      persistedAreaDirectiveMember,
+    await expect(
+      service.create(areaDirectiveMemberDto, undefined, accessActor),
+    ).resolves.toEqual(persistedAreaDirectiveMember);
+    expect(auditService.record).toHaveBeenCalledWith(
+      accessActor,
+      expect.objectContaining({
+        action: 'create',
+        entityType: 'Member',
+        entityId: persistedAreaDirectiveMember.id,
+      }),
+      expect.anything(),
     );
     expect(areasRepository.exists).toHaveBeenCalledWith({
       where: { id: 3, isArchived: false },

--- a/apps/backend/src/members/members.service.spec.ts
+++ b/apps/backend/src/members/members.service.spec.ts
@@ -19,6 +19,7 @@ import { Member } from './member.entity';
 import { MembersService } from './members.service';
 import { AreaMembership } from '../area-memberships/entities/area-membership.entity';
 import { toMemberResponse } from './utils/member-response.util';
+import { AuditService } from '../audit/audit.service';
 
 type MemberRepositoryMock = Partial<
   Record<keyof Repository<Member>, jest.Mock>
@@ -155,6 +156,13 @@ describe('MembersService', () => {
         {
           provide: DataSource,
           useValue: mockDataSource,
+        },
+        {
+          provide: AuditService,
+          useValue: {
+            record: jest.fn(),
+            findAll: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/apps/backend/src/members/members.service.ts
+++ b/apps/backend/src/members/members.service.ts
@@ -28,6 +28,7 @@ import { MemberActivityStatus } from './enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from './enums/member-availability-status.enum';
 import { Member } from './member.entity';
 import { toMemberResponse } from './utils/member-response.util';
+import { AuditService } from '../audit/audit.service';
 
 interface LegacyCreateMemberInput extends CreateMemberDto {
   status?: MemberAvailabilityStatus;
@@ -49,15 +50,17 @@ export class MembersService {
     @InjectRepository(AreaMembership)
     private readonly areaMembershipsRepository: Repository<AreaMembership>,
     private readonly dataSource: DataSource,
+    private readonly auditService: AuditService,
   ) {}
 
   async create(
     createMemberDto: CreateMemberDto,
     entityManager?: EntityManager,
+    accessActor?: RequestAccessActor,
   ): Promise<Member> {
     if (!entityManager) {
       return this.dataSource.transaction(async (em) =>
-        this.create(createMemberDto, em),
+        this.create(createMemberDto, em, accessActor),
       );
     }
     const { skills, areaId, status, ...restDto } =
@@ -95,6 +98,24 @@ export class MembersService {
       await areaMembershipsRepository.save(membership);
 
       savedMember.memberships = [membership];
+
+      if (accessActor) {
+        await this.auditService.record(
+          accessActor,
+          {
+            action: 'create',
+            entityType: 'Member',
+            entityId: savedMember.id,
+            areaId: areaId ?? null,
+            metadata: {
+              firstNames: savedMember.firstNames,
+              lastNames: savedMember.lastNames,
+            },
+          },
+          entityManager,
+        );
+      }
+
       return savedMember;
     } catch (error) {
       if (isUniqueViolation(error)) {
@@ -113,10 +134,11 @@ export class MembersService {
     id: number,
     updateMemberDto: UpdateMemberDto,
     entityManager?: EntityManager,
+    accessActor?: RequestAccessActor,
   ): Promise<Member> {
     if (!entityManager) {
       return this.dataSource.transaction(async (em) =>
-        this.update(id, updateMemberDto, em),
+        this.update(id, updateMemberDto, em, accessActor),
       );
     }
     const {
@@ -225,6 +247,23 @@ export class MembersService {
       where: { member: { id } },
     });
 
+    if (accessActor) {
+      await this.auditService.record(
+        accessActor,
+        {
+          action: 'update',
+          entityType: 'Member',
+          entityId: savedMember.id,
+          areaId: areaId !== undefined ? areaId : (savedMember.areaId ?? null),
+          metadata: {
+            firstNames: savedMember.firstNames,
+            lastNames: savedMember.lastNames,
+          },
+        },
+        entityManager,
+      );
+    }
+
     return savedMember;
   }
 
@@ -254,7 +293,20 @@ export class MembersService {
     member.activityStatus = MemberActivityStatus.INACTIVE;
     member.availabilityStatus = MemberAvailabilityStatus.DISABLED;
 
-    return this.membersRepository.save(member);
+    const savedMember = await this.membersRepository.save(member);
+
+    await this.auditService.record(accessActor, {
+      action: 'deactivate',
+      entityType: 'Member',
+      entityId: savedMember.id,
+      areaId: savedMember.areaId ?? null,
+      metadata: {
+        firstNames: savedMember.firstNames,
+        lastNames: savedMember.lastNames,
+      },
+    });
+
+    return savedMember;
   }
 
   findAll(filterDto?: GetMembersFilterDto): Promise<Member[]> {

--- a/apps/backend/src/migrations/1787788800003-CreateAuditEventsTable.spec.ts
+++ b/apps/backend/src/migrations/1787788800003-CreateAuditEventsTable.spec.ts
@@ -1,0 +1,40 @@
+import { QueryRunner } from 'typeorm';
+import { CreateAuditEventsTable1787788800003 } from './1787788800003-CreateAuditEventsTable';
+
+describe('CreateAuditEventsTable1787788800003', () => {
+  it('creates the audit_events table and its indexes', async () => {
+    const executedQueries: string[] = [];
+    const queryRunner = {
+      query: jest.fn((sql: string) => {
+        const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+        executedQueries.push(normalizedSql);
+        return Promise.resolve([]);
+      }),
+    } as unknown as QueryRunner;
+
+    await new CreateAuditEventsTable1787788800003().up(queryRunner);
+
+    expect(
+      executedQueries.some((sql) =>
+        sql.startsWith('CREATE TABLE IF NOT EXISTS audit_events'),
+      ),
+    ).toBe(true);
+    expect(
+      executedQueries.filter((sql) => sql.startsWith('CREATE INDEX')),
+    ).toHaveLength(4);
+  });
+
+  it('drops audit_events table in down method', async () => {
+    const executedQueries: string[] = [];
+    const queryRunner = {
+      query: jest.fn((sql: string) => {
+        executedQueries.push(sql);
+        return Promise.resolve([]);
+      }),
+    } as unknown as QueryRunner;
+
+    await new CreateAuditEventsTable1787788800003().down(queryRunner);
+
+    expect(executedQueries).toEqual(['DROP TABLE IF EXISTS audit_events;']);
+  });
+});

--- a/apps/backend/src/migrations/1787788800003-CreateAuditEventsTable.ts
+++ b/apps/backend/src/migrations/1787788800003-CreateAuditEventsTable.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAuditEventsTable1787788800003 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS audit_events (
+        id SERIAL PRIMARY KEY,
+        actor_id INTEGER NOT NULL,
+        actor_name VARCHAR(255) NOT NULL,
+        actor_role VARCHAR(50) NOT NULL,
+        action VARCHAR(50) NOT NULL,
+        entity_type VARCHAR(100) NOT NULL,
+        entity_id VARCHAR(50) NOT NULL,
+        area_id INTEGER,
+        timestamp TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        metadata TEXT
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_audit_events_area_id" ON audit_events (area_id);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_audit_events_actor_id" ON audit_events (actor_id);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_audit_events_entity" ON audit_events (entity_type, entity_id);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_audit_events_timestamp" ON audit_events (timestamp DESC);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE IF EXISTS audit_events;');
+  }
+}

--- a/apps/backend/src/projects/projects.module.ts
+++ b/apps/backend/src/projects/projects.module.ts
@@ -10,6 +10,7 @@ import { Project } from './entities/project.entity';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 import { TaskAssignee } from '../tasks/entities/task-assignee.entity';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { TaskAssignee } from '../tasks/entities/task-assignee.entity';
       Member,
       TaskAssignee,
     ]),
+    AuditModule,
   ],
   controllers: [ProjectsController],
   providers: [ProjectsService],

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -33,6 +33,7 @@ import { Project } from './entities/project.entity';
 import { ProjectStatus } from './enums/project-status.enum';
 import { ProjectsService } from './projects.service';
 import { TaskAssignee } from '../tasks/entities/task-assignee.entity';
+import { AuditService } from '../audit/audit.service';
 
 type RepositoryMethodMocks<T extends ObjectLiteral> = Partial<
   Record<Exclude<keyof Repository<T>, 'manager'>, jest.Mock>
@@ -330,6 +331,13 @@ describe('ProjectsService', () => {
         {
           provide: AreaService,
           useValue: mockAreaService,
+        },
+        {
+          provide: AuditService,
+          useValue: {
+            record: jest.fn(),
+            findAll: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import {
   BadRequestException,
   ConflictException,
@@ -203,6 +204,7 @@ describe('ProjectsService', () => {
   let projectMembershipsRepository: ProjectMembershipRepositoryMock;
   let membersRepository: MemberRepositoryMock;
   let taskAssigneesRepository: TaskAssigneeRepositoryMock;
+  let auditService: jest.Mocked<AuditService>;
 
   const mockAreaService = {
     findOne: jest.fn(),
@@ -343,6 +345,7 @@ describe('ProjectsService', () => {
     }).compile();
 
     service = module.get<ProjectsService>(ProjectsService);
+    auditService = module.get(AuditService);
   });
 
   it('creates a project with default phases when the area exists', async () => {
@@ -363,6 +366,15 @@ describe('ProjectsService', () => {
       ...project,
       phases,
     });
+    expect(auditService.record).toHaveBeenCalledWith(
+      presidencyActor,
+      expect.objectContaining({
+        action: 'create',
+        entityType: 'Project',
+        entityId: project.id,
+      }),
+      expect.anything(),
+    );
     expect(mockAreaService.findOne).toHaveBeenCalledWith(1);
     expect(projectsRepository.create).toHaveBeenCalledWith({
       name: createProjectDto.name,

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -40,6 +40,7 @@ import { ProjectPhase } from './entities/project-phase.entity';
 import { Project } from './entities/project.entity';
 import { ProjectStatus } from './enums/project-status.enum';
 import { TaskAssignee } from '../tasks/entities/task-assignee.entity';
+import { AuditService } from '../audit/audit.service';
 
 @Injectable()
 export class ProjectsService {
@@ -59,6 +60,7 @@ export class ProjectsService {
     @InjectRepository(TaskAssignee)
     private readonly taskAssigneesRepository: Repository<TaskAssignee>,
     private readonly areaService: AreaService,
+    private readonly auditService: AuditService,
   ) {}
 
   async create(
@@ -99,6 +101,20 @@ export class ProjectsService {
           entityManager.getRepository(ProjectLink),
         );
         savedProject.labels = labels;
+
+        if (accessActor) {
+          await this.auditService.record(
+            accessActor,
+            {
+              action: 'create',
+              entityType: 'Project',
+              entityId: savedProject.id,
+              areaId: savedProject.areaId,
+              metadata: { name: savedProject.name },
+            },
+            entityManager,
+          );
+        }
 
         return savedProject;
       },
@@ -252,7 +268,7 @@ export class ProjectsService {
         );
       }
 
-      await projectsRepository.save(project);
+      const savedProject = await projectsRepository.save(project);
 
       if (updateProjectDto.links !== undefined) {
         await this.replaceLinks(
@@ -260,6 +276,20 @@ export class ProjectsService {
           updateProjectDto.links,
           entityManager.getRepository(ProjectLink),
           true,
+        );
+      }
+
+      if (accessActor) {
+        await this.auditService.record(
+          accessActor,
+          {
+            action: 'update',
+            entityType: 'Project',
+            entityId: savedProject.id,
+            areaId: savedProject.areaId,
+            metadata: { name: savedProject.name },
+          },
+          entityManager,
         );
       }
     });
@@ -272,7 +302,17 @@ export class ProjectsService {
     this.assertProjectManagementAccess(project, accessActor);
     project.isArchived = true;
 
-    return this.projectsRepository.save(project);
+    const savedProject = await this.projectsRepository.save(project);
+
+    await this.auditService.record(accessActor, {
+      action: 'archive',
+      entityType: 'Project',
+      entityId: savedProject.id,
+      areaId: savedProject.areaId,
+      metadata: { name: savedProject.name },
+    });
+
+    return savedProject;
   }
 
   async findPhases(
@@ -517,10 +557,33 @@ export class ProjectsService {
 
         try {
           const saved = await projectMembershipsRepository.save(membership);
-          return projectMembershipsRepository.findOne({
+          const populated = (await projectMembershipsRepository.findOne({
             where: { id: saved.id },
             relations: ['member'],
-          }) as Promise<ProjectMembership>;
+          })) as ProjectMembership;
+
+          if (accessActor) {
+            await this.auditService.record(
+              accessActor,
+              {
+                action: 'team_assignment',
+                entityType: 'ProjectMembership',
+                entityId: populated.id,
+                areaId: project.areaId,
+                metadata: {
+                  projectId: project.id,
+                  projectName: project.name,
+                  memberId: member.id,
+                  memberNames: `${member.firstNames} ${member.lastNames}`,
+                  role: populated.role,
+                  type: 'add',
+                },
+              },
+              entityManager,
+            );
+          }
+
+          return populated;
         } catch (error) {
           if (isUniqueViolation(error)) {
             throw new ConflictException(
@@ -586,7 +649,32 @@ export class ProjectsService {
       );
     }
 
+    const project = await this.projectsRepository.findOne({
+      where: { id: projectId },
+      select: ['id', 'name', 'areaId'],
+    });
+    const member = await this.membersRepository.findOne({
+      where: { id: memberId },
+      select: ['id', 'firstNames', 'lastNames'],
+    });
+
     await this.projectMembershipsRepository.remove(membership);
+
+    if (accessActor && project && member) {
+      await this.auditService.record(accessActor, {
+        action: 'team_assignment',
+        entityType: 'ProjectMembership',
+        entityId: membership.id,
+        areaId: project.areaId,
+        metadata: {
+          projectId: project.id,
+          projectName: project.name,
+          memberId: member.id,
+          memberNames: `${member.firstNames} ${member.lastNames}`,
+          type: 'remove',
+        },
+      });
+    }
   }
 
   private validateDateRange(dateRange: {

--- a/apps/backend/src/tasks/tasks.module.ts
+++ b/apps/backend/src/tasks/tasks.module.ts
@@ -10,6 +10,7 @@ import { TaskStatusHistory } from './entities/task-status-history.entity';
 import { Task } from './entities/task.entity';
 import { TasksController } from './tasks.controller';
 import { TasksService } from './tasks.service';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { TasksService } from './tasks.service';
       ProjectPhase,
       ProjectMembership,
     ]),
+    AuditModule,
   ],
   controllers: [TasksController],
   providers: [TasksService],

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -20,6 +20,7 @@ import { TaskStatusHistory } from './entities/task-status-history.entity';
 import { TaskPriority } from './enums/task-priority.enum';
 import { TaskStatus } from './enums/task-status.enum';
 import { TasksService } from './tasks.service';
+import { AuditService } from '../audit/audit.service';
 
 const createMember = (overrides: Partial<Member> = {}): Member =>
   ({
@@ -242,6 +243,13 @@ describe('TasksService', () => {
         {
           provide: getRepositoryToken(ProjectMembership),
           useValue: projectMembershipsRepository,
+        },
+        {
+          provide: AuditService,
+          useValue: {
+            record: jest.fn(),
+            findAll: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -144,6 +145,7 @@ const memberActor: RequestAccessActor = {
 
 describe('TasksService', () => {
   let service: TasksService;
+  let auditService: jest.Mocked<AuditService>;
   let tasksRepository: {
     create: jest.Mock;
     save: jest.Mock;
@@ -255,6 +257,7 @@ describe('TasksService', () => {
     }).compile();
 
     service = module.get(TasksService);
+    auditService = module.get(AuditService);
   });
 
   describe('create', () => {
@@ -279,6 +282,14 @@ describe('TasksService', () => {
       await expect(
         service.create(createTaskDto, presidencyActor),
       ).resolves.toEqual(savedTask);
+      expect(auditService.record).toHaveBeenCalledWith(
+        presidencyActor,
+        expect.objectContaining({
+          action: 'create',
+          entityType: 'Task',
+        }),
+        expect.anything(),
+      );
       expect(tasksRepository.create).toHaveBeenCalledWith({
         projectId: 1,
         phaseId: 10,

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -28,6 +28,7 @@ import { Task } from './entities/task.entity';
 import { TaskStatusHistory } from './entities/task-status-history.entity';
 import { TaskPriority } from './enums/task-priority.enum';
 import { TaskStatus } from './enums/task-status.enum';
+import { AuditService } from '../audit/audit.service';
 
 type TaskAccessMode = 'read' | 'manage' | 'status';
 
@@ -55,6 +56,7 @@ export class TasksService {
     private readonly projectPhasesRepository: Repository<ProjectPhase>,
     @InjectRepository(ProjectMembership)
     private readonly projectMembershipsRepository: Repository<ProjectMembership>,
+    private readonly auditService: AuditService,
   ) {}
 
   async create(
@@ -120,6 +122,21 @@ export class TasksService {
         );
 
         await taskAssigneesRepository.save(assignees);
+
+        if (accessActor) {
+          await this.auditService.record(
+            accessActor,
+            {
+              action: 'create',
+              entityType: 'Task',
+              entityId: savedTask.id,
+              areaId: project.areaId,
+              metadata: { title: savedTask.title },
+            },
+            entityManager,
+          );
+        }
+
         return savedTask.id;
       },
     );
@@ -260,7 +277,21 @@ export class TasksService {
         task.phaseId = updateTaskDto.phaseId;
       }
 
-      await tasksRepository.save(task);
+      const savedTask = await tasksRepository.save(task);
+
+      if (accessActor) {
+        await this.auditService.record(
+          accessActor,
+          {
+            action: 'update',
+            entityType: 'Task',
+            entityId: savedTask.id,
+            areaId: project.areaId,
+            metadata: { title: savedTask.title },
+          },
+          entityManager,
+        );
+      }
     });
 
     return this.findOne(id, accessActor);
@@ -302,7 +333,7 @@ export class TasksService {
       const previousStatus = task.status;
       task.status = updateTaskStatusDto.status;
       await tasksRepository.save(task);
-      await taskStatusHistoryRepository.save(
+      const historyEntry = await taskStatusHistoryRepository.save(
         taskStatusHistoryRepository.create({
           taskId: task.id,
           previousStatus,
@@ -310,6 +341,25 @@ export class TasksService {
           actorId: this.getActorMemberId(accessActor),
         }),
       );
+
+      if (accessActor) {
+        await this.auditService.record(
+          accessActor,
+          {
+            action: 'task_status_transition',
+            entityType: 'TaskStatusHistory',
+            entityId: historyEntry.id,
+            areaId: project.areaId,
+            metadata: {
+              taskId: task.id,
+              taskTitle: task.title,
+              previousStatus,
+              newStatus: updateTaskStatusDto.status,
+            },
+          },
+          entityManager,
+        );
+      }
     });
 
     return this.findOne(id, accessActor);
@@ -411,6 +461,24 @@ export class TasksService {
           }),
         ),
       );
+
+      if (accessActor) {
+        await this.auditService.record(
+          accessActor,
+          {
+            action: 'task_assignment',
+            entityType: 'TaskAssignee',
+            entityId: task.id,
+            areaId: project.areaId,
+            metadata: {
+              taskId: task.id,
+              taskTitle: task.title,
+              assigneeMemberIds: setTaskAssigneesDto.memberIds,
+            },
+          },
+          entityManager,
+        );
+      }
     });
 
     return this.findOne(id, accessActor);

--- a/apps/frontend/src/app/audit-management.tsx
+++ b/apps/frontend/src/app/audit-management.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { API_URL, getJson } from "@/lib/auth-client";
+
+export type AuditEvent = {
+  id: number;
+  actorId: number;
+  actorName: string;
+  actorRole: string;
+  action: string;
+  targetType: string;
+  targetId: string;
+  areaId: number | null;
+  metadata: Record<string, unknown> | null;
+  ipAddress: string | null;
+  createdAt: string;
+};
+
+export type AuditResponse = {
+  data: AuditEvent[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    lastPage: number;
+  };
+};
+
+type AuditManagementProps = {
+  accessToken: string;
+};
+
+const ACTION_LABELS: Record<string, { label: string; bg: string; text: string }> = {
+  create: { label: "Creación", bg: "bg-emerald-100 dark:bg-emerald-950/60", text: "text-emerald-700 dark:text-emerald-300" },
+  update: { label: "Edición", bg: "bg-amber-100 dark:bg-amber-950/60", text: "text-amber-700 dark:text-amber-300" },
+  archive: { label: "Archivado", bg: "bg-rose-100 dark:bg-rose-950/60", text: "text-rose-700 dark:text-rose-300" },
+  deactivate: { label: "Desactivación", bg: "bg-rose-100 dark:bg-rose-950/60", text: "text-rose-700 dark:text-rose-300" },
+  team_assignment: { label: "Equipo", bg: "bg-indigo-100 dark:bg-indigo-950/60", text: "text-indigo-700 dark:text-indigo-300" },
+  task_status_transition: { label: "Estado Tarea", bg: "bg-blue-100 dark:bg-blue-950/60", text: "text-blue-700 dark:text-blue-300" },
+  task_assignment: { label: "Asignación Tarea", bg: "bg-violet-100 dark:bg-violet-950/60", text: "text-violet-700 dark:text-violet-300" },
+};
+
+const TARGET_TYPE_LABELS: Record<string, string> = {
+  area: "Área",
+  member: "Miembro",
+  project: "Proyecto",
+  task: "Tarea",
+};
+
+export default function AuditManagementView({ accessToken }: AuditManagementProps) {
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [meta, setMeta] = useState({ total: 0, page: 1, limit: 10, lastPage: 1 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
+
+  // Filters
+  const [targetTypeFilter, setTargetTypeFilter] = useState("");
+  const [actionFilter, setActionFilter] = useState("");
+  const [fromDateFilter, setFromDateFilter] = useState("");
+  const [toDateFilter, setToDateFilter] = useState("");
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    let ignore = false;
+    async function loadAuditEvents() {
+      setLoading(true);
+      setError("");
+      try {
+        const queryParams = new URLSearchParams();
+        queryParams.set("page", page.toString());
+        queryParams.set("limit", "10");
+        if (targetTypeFilter) queryParams.set("targetType", targetTypeFilter);
+        if (actionFilter) queryParams.set("action", actionFilter);
+        if (fromDateFilter) queryParams.set("fromDate", fromDateFilter);
+        if (toDateFilter) queryParams.set("toDate", toDateFilter);
+
+        const response = await getJson<AuditResponse>(`/audit?${queryParams.toString()}`, accessToken);
+        if (!ignore) {
+          setEvents(response.data);
+          setMeta(response.meta);
+        }
+      } catch (err: unknown) {
+        if (!ignore) {
+          setError(err instanceof Error ? err.message : "Error al cargar eventos de auditoría");
+        }
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+
+    loadAuditEvents();
+    return () => {
+      ignore = true;
+    };
+  }, [accessToken, page, targetTypeFilter, actionFilter, fromDateFilter, toDateFilter]);
+
+  const formatDate = (dateStr: string) => {
+    try {
+      const d = new Date(dateStr);
+      return d.toLocaleString("es-PE", {
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+    } catch {
+      return dateStr;
+    }
+  };
+
+  const renderActionBadge = (action: string) => {
+    const config = ACTION_LABELS[action] || {
+      label: action,
+      bg: "bg-gray-100 dark:bg-gray-800",
+      text: "text-gray-700 dark:text-gray-300",
+    };
+    return (
+      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${config.bg} ${config.text}`}>
+        {config.label}
+      </span>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 bg-white dark:bg-slate-900 p-6 rounded-2xl border border-slate-200 dark:border-slate-800 shadow-sm">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
+            <svg className="w-7 h-7 text-indigo-600 dark:text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>
+            Bitácora de Auditoría
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+            Historial inmutable y trazabilidad de acciones clave realizadas en la plataforma (V1).
+          </p>
+        </div>
+      </div>
+
+      {/* Filters Bar */}
+      <div className="bg-white dark:bg-slate-900 p-4 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm flex flex-wrap gap-4 items-center justify-between">
+        <div className="flex flex-wrap gap-3 items-center">
+          <div>
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Entidad Afectada</label>
+            <select
+              value={targetTypeFilter}
+              onChange={(e) => {
+                setTargetTypeFilter(e.target.value);
+                setPage(1);
+              }}
+              className="px-3 py-1.5 text-sm rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+            >
+              <option value="">Todas las entidades</option>
+              <option value="area">Área</option>
+              <option value="member">Miembro</option>
+              <option value="project">Proyecto</option>
+              <option value="task">Tarea</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Tipo de Acción</label>
+            <select
+              value={actionFilter}
+              onChange={(e) => {
+                setActionFilter(e.target.value);
+                setPage(1);
+              }}
+              className="px-3 py-1.5 text-sm rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+            >
+              <option value="">Todas las acciones</option>
+              <option value="create">Creación</option>
+              <option value="update">Edición</option>
+              <option value="archive">Archivado</option>
+              <option value="deactivate">Desactivación</option>
+              <option value="team_assignment">Equipo de Proyecto</option>
+              <option value="task_status_transition">Cambio Estado Tarea</option>
+              <option value="task_assignment">Asignación Tarea</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Desde</label>
+            <input
+              type="date"
+              value={fromDateFilter}
+              onChange={(e) => {
+                setFromDateFilter(e.target.value);
+                setPage(1);
+              }}
+              className="px-3 py-1.5 text-sm rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Hasta</label>
+            <input
+              type="date"
+              value={toDateFilter}
+              onChange={(e) => {
+                setToDateFilter(e.target.value);
+                setPage(1);
+              }}
+              className="px-3 py-1.5 text-sm rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="text-xs text-slate-500 dark:text-slate-400 font-medium">
+          Total: {meta.total} registro{meta.total !== 1 ? "s" : ""}
+        </div>
+      </div>
+
+      {/* Table & Content */}
+      <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 shadow-sm overflow-hidden">
+        {error && (
+          <div className="p-4 bg-rose-50 dark:bg-rose-950/40 border-b border-rose-200 dark:border-rose-900 text-rose-700 dark:text-rose-300 text-sm">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="p-12 text-center text-slate-400 dark:text-slate-500">
+            <svg className="w-8 h-8 animate-spin mx-auto text-indigo-500 mb-2" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+            </svg>
+            Cargando registros de auditoría...
+          </div>
+        ) : events.length === 0 ? (
+          <div className="p-12 text-center text-slate-500 dark:text-slate-400">
+            No se encontraron eventos de auditoría con los filtros seleccionados.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm border-collapse">
+              <thead>
+                <tr className="bg-slate-50 dark:bg-slate-800/60 border-b border-slate-200 dark:border-slate-800 text-slate-600 dark:text-slate-400 text-xs uppercase tracking-wider font-semibold">
+                  <th className="px-6 py-3.5">Fecha y Hora</th>
+                  <th className="px-6 py-3.5">Actor</th>
+                  <th className="px-6 py-3.5">Acción</th>
+                  <th className="px-6 py-3.5">Entidad</th>
+                  <th className="px-6 py-3.5 text-right">Detalles</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800/60">
+                {events.map((ev) => (
+                  <tr key={ev.id} className="hover:bg-slate-50/80 dark:hover:bg-slate-800/40 transition-colors">
+                    <td className="px-6 py-4 whitespace-nowrap text-slate-600 dark:text-slate-300 font-mono text-xs">
+                      {formatDate(ev.createdAt)}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="font-medium text-slate-900 dark:text-slate-100">{ev.actorName || `ID ${ev.actorId}`}</div>
+                      <div className="text-xs text-slate-400 uppercase tracking-wider">{ev.actorRole}</div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      {renderActionBadge(ev.action)}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-slate-700 dark:text-slate-300 font-medium">
+                      <span className="capitalize">{TARGET_TYPE_LABELS[ev.targetType] || ev.targetType}</span> #{ev.targetId}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-right">
+                      <button
+                        onClick={() => setSelectedEvent(ev)}
+                        className="px-3 py-1 text-xs font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 bg-indigo-50 dark:bg-indigo-950/60 hover:bg-indigo-100 rounded-lg transition-colors"
+                      >
+                        Ver metadata
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Pagination Footer */}
+        {!loading && events.length > 0 && (
+          <div className="px-6 py-4 border-t border-slate-200 dark:border-slate-800 flex items-center justify-between">
+            <div className="text-xs text-slate-500 dark:text-slate-400">
+              Página <span className="font-semibold text-slate-800 dark:text-slate-200">{meta.page}</span> de{" "}
+              <span className="font-semibold text-slate-800 dark:text-slate-200">{meta.lastPage}</span>
+            </div>
+            <div className="flex gap-2">
+              <button
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                className="px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-300 dark:border-slate-700 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-700 dark:text-slate-200 transition-colors"
+              >
+                Anterior
+              </button>
+              <button
+                disabled={page >= meta.lastPage}
+                onClick={() => setPage((p) => p + 1)}
+                className="px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-300 dark:border-slate-700 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-700 dark:text-slate-200 transition-colors"
+              >
+                Siguiente
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Metadata Detail Modal */}
+      {selectedEvent && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm">
+          <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 max-w-lg w-full p-6 shadow-2xl space-y-4">
+            <div className="flex items-center justify-between border-b border-slate-100 dark:border-slate-800 pb-3">
+              <h3 className="font-bold text-slate-900 dark:text-white flex items-center gap-2">
+                <span>Detalles del Evento #{selectedEvent.id}</span>
+              </h3>
+              <button
+                onClick={() => setSelectedEvent(null)}
+                className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 text-xl font-bold"
+              >
+                &times;
+              </button>
+            </div>
+
+            <div className="space-y-2 text-xs text-slate-600 dark:text-slate-300">
+              <div><strong className="text-slate-900 dark:text-white">Actor:</strong> {selectedEvent.actorName} ({selectedEvent.actorRole})</div>
+              <div><strong className="text-slate-900 dark:text-white">Acción:</strong> {selectedEvent.action}</div>
+              <div><strong className="text-slate-900 dark:text-white">Entidad Target:</strong> {selectedEvent.targetType} #{selectedEvent.targetId}</div>
+              <div><strong className="text-slate-900 dark:text-white">Fecha UTC:</strong> {selectedEvent.createdAt}</div>
+              {selectedEvent.ipAddress && <div><strong className="text-slate-900 dark:text-white">IP:</strong> {selectedEvent.ipAddress}</div>}
+            </div>
+
+            <div>
+              <label className="block text-xs font-semibold text-slate-700 dark:text-slate-300 mb-1">Metadata (JSON):</label>
+              <pre className="bg-slate-950 text-slate-100 p-4 rounded-xl text-xs overflow-x-auto font-mono max-h-60">
+                {JSON.stringify(selectedEvent.metadata, null, 2)}
+              </pre>
+            </div>
+
+            <div className="pt-2 text-right">
+              <button
+                onClick={() => setSelectedEvent(null)}
+                className="px-4 py-2 bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700 text-slate-800 dark:text-slate-200 text-xs font-medium rounded-xl transition-colors"
+              >
+                Cerrar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/audit-management.tsx
+++ b/apps/frontend/src/app/audit-management.tsx
@@ -51,8 +51,14 @@ const ENTITY_TYPE_LABELS: Record<string, string> = {
   member: "Miembro",
   Project: "Proyecto",
   project: "Proyecto",
+  ProjectMembership: "Equipo de Proyecto",
+  projectmembership: "Equipo de Proyecto",
   Task: "Tarea",
   task: "Tarea",
+  TaskStatusHistory: "Estado de Tarea",
+  taskstatushistory: "Estado de Tarea",
+  TaskAssignee: "Asignación de Tarea",
+  taskassignee: "Asignación de Tarea",
 };
 
 export default function AuditManagementView({ accessToken }: AuditManagementProps) {
@@ -182,7 +188,10 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
               <option value="Area">Área</option>
               <option value="Member">Miembro</option>
               <option value="Project">Proyecto</option>
+              <option value="ProjectMembership">Equipo de Proyecto</option>
               <option value="Task">Tarea</option>
+              <option value="TaskStatusHistory">Estado de Tarea</option>
+              <option value="TaskAssignee">Asignación de Tarea</option>
             </select>
           </div>
 

--- a/apps/frontend/src/app/audit-management.tsx
+++ b/apps/frontend/src/app/audit-management.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { API_URL, getJson } from "@/lib/auth-client";
+import { getJson } from "@/lib/auth-client";
 
 export type AuditEvent = {
   id: number;
@@ -9,12 +9,15 @@ export type AuditEvent = {
   actorName: string;
   actorRole: string;
   action: string;
-  targetType: string;
-  targetId: string;
+  entityType?: string;
+  targetType?: string;
+  entityId?: string;
+  targetId?: string;
   areaId: number | null;
-  metadata: Record<string, unknown> | null;
-  ipAddress: string | null;
-  createdAt: string;
+  metadata: string | Record<string, unknown> | null;
+  ipAddress?: string | null;
+  timestamp?: string;
+  createdAt?: string;
 };
 
 export type AuditResponse = {
@@ -41,7 +44,7 @@ const ACTION_LABELS: Record<string, { label: string; bg: string; text: string }>
   task_assignment: { label: "Asignación Tarea", bg: "bg-violet-100 dark:bg-violet-950/60", text: "text-violet-700 dark:text-violet-300" },
 };
 
-const TARGET_TYPE_LABELS: Record<string, string> = {
+const ENTITY_TYPE_LABELS: Record<string, string> = {
   area: "Área",
   member: "Miembro",
   project: "Proyecto",
@@ -56,10 +59,10 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
   const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
 
   // Filters
-  const [targetTypeFilter, setTargetTypeFilter] = useState("");
+  const [entityTypeFilter, setEntityTypeFilter] = useState("");
   const [actionFilter, setActionFilter] = useState("");
-  const [fromDateFilter, setFromDateFilter] = useState("");
-  const [toDateFilter, setToDateFilter] = useState("");
+  const [dateFromFilter, setDateFromFilter] = useState("");
+  const [dateToFilter, setDateToFilter] = useState("");
   const [page, setPage] = useState(1);
 
   useEffect(() => {
@@ -71,10 +74,10 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
         const queryParams = new URLSearchParams();
         queryParams.set("page", page.toString());
         queryParams.set("limit", "10");
-        if (targetTypeFilter) queryParams.set("targetType", targetTypeFilter);
+        if (entityTypeFilter) queryParams.set("entityType", entityTypeFilter);
         if (actionFilter) queryParams.set("action", actionFilter);
-        if (fromDateFilter) queryParams.set("fromDate", fromDateFilter);
-        if (toDateFilter) queryParams.set("toDate", toDateFilter);
+        if (dateFromFilter) queryParams.set("dateFrom", dateFromFilter);
+        if (dateToFilter) queryParams.set("dateTo", dateToFilter);
 
         const response = await getJson<AuditResponse>(`/audit?${queryParams.toString()}`, accessToken);
         if (!ignore) {
@@ -94,11 +97,13 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
     return () => {
       ignore = true;
     };
-  }, [accessToken, page, targetTypeFilter, actionFilter, fromDateFilter, toDateFilter]);
+  }, [accessToken, page, entityTypeFilter, actionFilter, dateFromFilter, dateToFilter]);
 
-  const formatDate = (dateStr: string) => {
+  const formatDate = (dateStr?: string) => {
+    if (!dateStr) return "-";
     try {
       const d = new Date(dateStr);
+      if (isNaN(d.getTime())) return dateStr;
       return d.toLocaleString("es-PE", {
         day: "2-digit",
         month: "short",
@@ -109,6 +114,20 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
       });
     } catch {
       return dateStr;
+    }
+  };
+
+  const parseMetadata = (rawMetadata: string | Record<string, unknown> | null): Record<string, unknown> | null => {
+    if (!rawMetadata) return null;
+    if (typeof rawMetadata === "object") return rawMetadata as Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(rawMetadata);
+      if (typeof parsed === "string") {
+        return JSON.parse(parsed);
+      }
+      return parsed;
+    } catch {
+      return { raw: rawMetadata };
     }
   };
 
@@ -148,9 +167,9 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
           <div>
             <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Entidad Afectada</label>
             <select
-              value={targetTypeFilter}
+              value={entityTypeFilter}
               onChange={(e) => {
-                setTargetTypeFilter(e.target.value);
+                setEntityTypeFilter(e.target.value);
                 setPage(1);
               }}
               className="px-3 py-1.5 text-sm rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
@@ -188,9 +207,9 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
             <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Desde</label>
             <input
               type="date"
-              value={fromDateFilter}
+              value={dateFromFilter}
               onChange={(e) => {
-                setFromDateFilter(e.target.value);
+                setDateFromFilter(e.target.value);
                 setPage(1);
               }}
               className="px-3 py-1.5 text-sm rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
@@ -201,9 +220,9 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
             <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Hasta</label>
             <input
               type="date"
-              value={toDateFilter}
+              value={dateToFilter}
               onChange={(e) => {
-                setToDateFilter(e.target.value);
+                setDateToFilter(e.target.value);
                 setPage(1);
               }}
               className="px-3 py-1.5 text-sm rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
@@ -249,31 +268,37 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800/60">
-                {events.map((ev) => (
-                  <tr key={ev.id} className="hover:bg-slate-50/80 dark:hover:bg-slate-800/40 transition-colors">
-                    <td className="px-6 py-4 whitespace-nowrap text-slate-600 dark:text-slate-300 font-mono text-xs">
-                      {formatDate(ev.createdAt)}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="font-medium text-slate-900 dark:text-slate-100">{ev.actorName || `ID ${ev.actorId}`}</div>
-                      <div className="text-xs text-slate-400 uppercase tracking-wider">{ev.actorRole}</div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      {renderActionBadge(ev.action)}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-slate-700 dark:text-slate-300 font-medium">
-                      <span className="capitalize">{TARGET_TYPE_LABELS[ev.targetType] || ev.targetType}</span> #{ev.targetId}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right">
-                      <button
-                        onClick={() => setSelectedEvent(ev)}
-                        className="px-3 py-1 text-xs font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 bg-indigo-50 dark:bg-indigo-950/60 hover:bg-indigo-100 rounded-lg transition-colors"
-                      >
-                        Ver metadata
-                      </button>
-                    </td>
-                  </tr>
-                ))}
+                {events.map((ev) => {
+                  const entityType = ev.entityType ?? ev.targetType ?? "desconocido";
+                  const entityId = ev.entityId ?? ev.targetId ?? "";
+                  const timestampStr = ev.timestamp ?? ev.createdAt;
+
+                  return (
+                    <tr key={ev.id} className="hover:bg-slate-50/80 dark:hover:bg-slate-800/40 transition-colors">
+                      <td className="px-6 py-4 whitespace-nowrap text-slate-600 dark:text-slate-300 font-mono text-xs">
+                        {formatDate(timestampStr)}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="font-medium text-slate-900 dark:text-slate-100">{ev.actorName || `ID ${ev.actorId}`}</div>
+                        <div className="text-xs text-slate-400 uppercase tracking-wider">{ev.actorRole}</div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        {renderActionBadge(ev.action)}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-slate-700 dark:text-slate-300 font-medium">
+                        <span className="capitalize">{ENTITY_TYPE_LABELS[entityType] || entityType}</span> #{entityId}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right">
+                        <button
+                          onClick={() => setSelectedEvent(ev)}
+                          className="px-3 py-1 text-xs font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 bg-indigo-50 dark:bg-indigo-950/60 hover:bg-indigo-100 rounded-lg transition-colors"
+                        >
+                          Ver metadata
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -325,15 +350,23 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
             <div className="space-y-2 text-xs text-slate-600 dark:text-slate-300">
               <div><strong className="text-slate-900 dark:text-white">Actor:</strong> {selectedEvent.actorName} ({selectedEvent.actorRole})</div>
               <div><strong className="text-slate-900 dark:text-white">Acción:</strong> {selectedEvent.action}</div>
-              <div><strong className="text-slate-900 dark:text-white">Entidad Target:</strong> {selectedEvent.targetType} #{selectedEvent.targetId}</div>
-              <div><strong className="text-slate-900 dark:text-white">Fecha UTC:</strong> {selectedEvent.createdAt}</div>
+              <div>
+                <strong className="text-slate-900 dark:text-white">Entidad Target:</strong>{" "}
+                {ENTITY_TYPE_LABELS[selectedEvent.entityType ?? selectedEvent.targetType ?? ""] || (selectedEvent.entityType ?? selectedEvent.targetType)} #{selectedEvent.entityId ?? selectedEvent.targetId}
+              </div>
+              <div>
+                <strong className="text-slate-900 dark:text-white">Fecha UTC:</strong> {formatDate(selectedEvent.timestamp ?? selectedEvent.createdAt)}
+              </div>
               {selectedEvent.ipAddress && <div><strong className="text-slate-900 dark:text-white">IP:</strong> {selectedEvent.ipAddress}</div>}
             </div>
 
             <div>
               <label className="block text-xs font-semibold text-slate-700 dark:text-slate-300 mb-1">Metadata (JSON):</label>
               <pre className="bg-slate-950 text-slate-100 p-4 rounded-xl text-xs overflow-x-auto font-mono max-h-60">
-                {JSON.stringify(selectedEvent.metadata, null, 2)}
+                {(() => {
+                  const parsed = parseMetadata(selectedEvent.metadata);
+                  return parsed ? JSON.stringify(parsed, null, 2) : "Sin metadata";
+                })()}
               </pre>
             </div>
 

--- a/apps/frontend/src/app/audit-management.tsx
+++ b/apps/frontend/src/app/audit-management.tsx
@@ -45,9 +45,13 @@ const ACTION_LABELS: Record<string, { label: string; bg: string; text: string }>
 };
 
 const ENTITY_TYPE_LABELS: Record<string, string> = {
+  Area: "Área",
   area: "Área",
+  Member: "Miembro",
   member: "Miembro",
+  Project: "Proyecto",
   project: "Proyecto",
+  Task: "Tarea",
   task: "Tarea",
 };
 
@@ -175,10 +179,10 @@ export default function AuditManagementView({ accessToken }: AuditManagementProp
               className="px-3 py-1.5 text-sm rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
             >
               <option value="">Todas las entidades</option>
-              <option value="area">Área</option>
-              <option value="member">Miembro</option>
-              <option value="project">Proyecto</option>
-              <option value="task">Tarea</option>
+              <option value="Area">Área</option>
+              <option value="Member">Miembro</option>
+              <option value="Project">Proyecto</option>
+              <option value="Task">Tarea</option>
             </select>
           </div>
 

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/auth-client";
 import ProjectManagement from "../project-management";
 import TaskManagement from "../task-management";
+import AuditManagementView from "../audit-management";
 import {
   AreaDetailManagementView,
   AreasManagementView,
@@ -381,7 +382,9 @@ export default function DashboardPage() {
             {view === "integrations" && (
               <PlaceholderView title="Integraciones" />
             )}
-            {view === "audit" && <PlaceholderView title="Auditoría" />}
+            {view === "audit" && accessToken && (
+              <AuditManagementView accessToken={accessToken} />
+            )}
             {view === "profile" && (
               <ProfileView member={currentMember} onLogout={handleLogout} />
             )}


### PR DESCRIPTION
Summary

Registers and displays basic audit events for key V1 actions, adding full backend audit instrumentation and a dedicated audit log frontend interface.

Changes

- Add AuditEvent entity, service, controller (GET /audit), and DTO for local PostgreSQL audit event storage.
- Implement audit event recording for key actions across Areas, Members, Projects, and Tasks modules.
- Persist immutable actor full names and enforce role-based access scoping (DIRECTIVA_DE_AREA area-scoped vs. PRESIDENCIA global).
- Add AuditManagementView frontend component with filtering (target entity, action type, date range), pagination, and JSON metadata detail modal.
- Restrict audit tab visibility in dashboard to PRESIDENCIA and DIRECTIVA_DE_AREA roles.
- Enrich AuthGuard access actor payload with authenticated member names for seamless traceability.
- Update unit test suites and controllers to mock AuditService and validate access actor passing.