### PR TITLE
Uni2 46 featmembers derive activity from active project task states

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { MigrateMemberRolesAndAreas1787788800000 } from './migrations/1787788800
 import { RepairMemberAreaMemberships1787788800001 } from './migrations/1787788800001-RepairMemberAreaMemberships';
 import { AddTaskCollaboration1787788800002 } from './migrations/1787788800002-AddTaskCollaboration';
 import { CreateAuditEventsTable1787788800003 } from './migrations/1787788800003-CreateAuditEventsTable';
+import { DeriveMemberActivityFromTasks1787788800004 } from './migrations/1787788800004-DeriveMemberActivityFromTasks';
 import { AuthModule } from './auth/auth.module';
 import { TasksModule } from './tasks/tasks.module';
 import { AuditModule } from './audit/audit.module';
@@ -42,6 +43,7 @@ import { AuditModule } from './audit/audit.module';
             RepairMemberAreaMemberships1787788800001,
             AddTaskCollaboration1787788800002,
             CreateAuditEventsTable1787788800003,
+            DeriveMemberActivityFromTasks1787788800004,
           ],
           migrationsRun: true,
         };

--- a/apps/backend/src/auth/auth.guard.spec.ts
+++ b/apps/backend/src/auth/auth.guard.spec.ts
@@ -132,7 +132,7 @@ describe('AuthGuard', () => {
     });
   });
 
-  it('rejects inactive authenticated members', async () => {
+  it('allows inactive authenticated members to access protected routes', async () => {
     const reflector = {
       getAllAndOverride: jest.fn().mockReturnValue(false),
     } as unknown as Reflector;
@@ -153,7 +153,7 @@ describe('AuthGuard', () => {
       guard.canActivate(
         createContext({ headers: { authorization: 'Bearer valid-token' } }),
       ),
-    ).rejects.toBeInstanceOf(UnauthorizedException);
+    ).resolves.toBe(true);
   });
 
   it('rejects disabled authenticated members', async () => {

--- a/apps/backend/src/auth/auth.guard.ts
+++ b/apps/backend/src/auth/auth.guard.ts
@@ -10,7 +10,6 @@ import { Repository } from 'typeorm';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { AccessControlledRequest } from '../common/interfaces/access-controlled-request.interface';
-import { MemberActivityStatus } from '../members/enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from '../members/enums/member-availability-status.enum';
 import { Member } from '../members/member.entity';
 import { AuthTokenService } from './auth-token.service';
@@ -45,7 +44,6 @@ export class AuthGuard implements CanActivate {
 
     if (
       !member ||
-      member.activityStatus !== MemberActivityStatus.ACTIVE ||
       member.availabilityStatus === MemberAvailabilityStatus.DISABLED
     ) {
       throw new UnauthorizedException('Authenticated member is disabled');

--- a/apps/backend/src/auth/auth.service.spec.ts
+++ b/apps/backend/src/auth/auth.service.spec.ts
@@ -86,7 +86,7 @@ describe('AuthService', () => {
       role: AreaRole.PRESIDENCIA,
       institution: 'UNI',
       studentCode: '20260004',
-      activityStatus: MemberActivityStatus.ACTIVE,
+      activityStatus: MemberActivityStatus.INACTIVE,
       sessionVersion: 0,
     } as Member;
 
@@ -150,14 +150,6 @@ describe('AuthService', () => {
       },
     },
     {
-      label: 'inactive',
-      member: {
-        institution: 'UNI',
-        studentCode: '20260004',
-        activityStatus: MemberActivityStatus.INACTIVE,
-      },
-    },
-    {
       label: 'without a student code',
       member: {
         institution: 'UNI',
@@ -187,13 +179,13 @@ describe('AuthService', () => {
     },
   );
 
-  it('returns a token for valid active credentials without exposing the hash', async () => {
+  it('returns a token for valid inactive credentials without exposing the hash', async () => {
     const member = {
       id: 7,
       institution: 'UNI',
       studentCode: '20260007',
       passwordHash: 'stored-hash',
-      activityStatus: MemberActivityStatus.ACTIVE,
+      activityStatus: MemberActivityStatus.INACTIVE,
       sessionVersion: 5,
     } as Member;
 

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -11,7 +11,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { createHash, timingSafeEqual } from 'crypto';
 import { Repository } from 'typeorm';
 import { AreaRole } from '../common/enums/area-role.enum';
-import { MemberActivityStatus } from '../members/enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from '../members/enums/member-availability-status.enum';
 import { Member } from '../members/member.entity';
 import { MembersService } from '../members/members.service';
@@ -153,7 +152,6 @@ export class AuthService {
       !member ||
       !member.passwordHash ||
       !credentialsAreValid ||
-      member.activityStatus !== MemberActivityStatus.ACTIVE ||
       member.availabilityStatus === MemberAvailabilityStatus.DISABLED
     ) {
       throw new UnauthorizedException('Invalid credentials');
@@ -212,22 +210,19 @@ export class AuthService {
     role: AreaRole;
     institution: string;
     studentCode?: string | null;
-    activityStatus?: MemberActivityStatus;
     availabilityStatus?: MemberAvailabilityStatus;
   }): void {
-    const activityStatus = member.activityStatus ?? MemberActivityStatus.ACTIVE;
     const availabilityStatus =
       member.availabilityStatus ?? MemberAvailabilityStatus.AVAILABLE;
 
     if (
       member.role !== AreaRole.PRESIDENCIA ||
       member.institution.trim().toUpperCase() !== 'UNI' ||
-      activityStatus !== MemberActivityStatus.ACTIVE ||
       availabilityStatus === MemberAvailabilityStatus.DISABLED ||
       !member.studentCode?.trim()
     ) {
       throw new ForbiddenException(
-        'The bootstrap member must be an active UNI Presidencia member with a student code',
+        'The bootstrap member must be an enabled UNI Presidencia member with a student code',
       );
     }
   }

--- a/apps/backend/src/members/dto/create-member.dto.ts
+++ b/apps/backend/src/members/dto/create-member.dto.ts
@@ -16,7 +16,6 @@ import {
   ValidatorConstraintInterface,
 } from 'class-validator';
 import { AreaRole } from '../../common/enums/area-role.enum';
-import { MemberActivityStatus } from '../enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from '../enums/member-availability-status.enum';
 
 const trimString = ({ value }: { value: unknown }) =>
@@ -125,10 +124,6 @@ export class CreateMemberDto {
   @IsString({ each: true })
   @Length(1, 80, { each: true })
   skills: string[];
-
-  @IsEnum(MemberActivityStatus)
-  @IsOptional()
-  activityStatus?: MemberActivityStatus;
 
   @IsEnum(MemberAvailabilityStatus)
   @IsOptional()

--- a/apps/backend/src/members/dto/update-member.dto.ts
+++ b/apps/backend/src/members/dto/update-member.dto.ts
@@ -9,7 +9,6 @@ import {
   Length,
   Min,
 } from 'class-validator';
-import { MemberActivityStatus } from '../enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from '../enums/member-availability-status.enum';
 
 const trimString = ({ value }: { value: unknown }): unknown =>
@@ -75,10 +74,6 @@ export class UpdateMemberDto {
   @Length(1, 80, { each: true })
   @IsOptional()
   skills?: string[];
-
-  @IsEnum(MemberActivityStatus)
-  @IsOptional()
-  activityStatus?: MemberActivityStatus;
 
   @IsEnum(MemberAvailabilityStatus)
   @IsOptional()

--- a/apps/backend/src/members/member-activity.service.spec.ts
+++ b/apps/backend/src/members/member-activity.service.spec.ts
@@ -1,0 +1,60 @@
+import { DataSource, EntityManager } from 'typeorm';
+import { MemberActivityService } from './member-activity.service';
+
+describe('MemberActivityService', () => {
+  const query = jest.fn();
+  const entityManager = { query } as unknown as EntityManager;
+  const dataSource = { manager: entityManager } as DataSource;
+  const service = new MemberActivityService(dataSource);
+
+  beforeEach(() => {
+    query.mockReset();
+  });
+
+  it('recalculates unique member IDs from active project task states', async () => {
+    query.mockResolvedValue([]);
+
+    await service.refreshMembers([3, 2, 3], entityManager);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "task.status::text IN ('in_progress', 'in_review')",
+      ),
+      [[3, 2]],
+    );
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("project.status::text = 'active'"),
+      [[3, 2]],
+    );
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('project.is_archived = FALSE'),
+      [[3, 2]],
+    );
+  });
+
+  it('does not query when no valid member IDs are supplied', async () => {
+    await service.refreshMembers([], entityManager);
+
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('refreshes every member assigned to tasks in a project', async () => {
+    query
+      .mockResolvedValueOnce([{ memberId: 4 }, { memberId: '7' }])
+      .mockResolvedValueOnce([]);
+
+    await service.refreshProjectMembers(10, entityManager);
+
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('WHERE task.project_id = $1'),
+      [10],
+    );
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('UPDATE members member'),
+      [[4, 7]],
+    );
+  });
+});

--- a/apps/backend/src/members/member-activity.service.ts
+++ b/apps/backend/src/members/member-activity.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, EntityManager } from 'typeorm';
+
+@Injectable()
+export class MemberActivityService {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async refreshMembers(
+    memberIds: number[],
+    entityManager: EntityManager = this.dataSource.manager,
+  ): Promise<void> {
+    const uniqueMemberIds = [
+      ...new Set(memberIds.filter((memberId) => Number.isInteger(memberId))),
+    ];
+
+    if (uniqueMemberIds.length === 0) {
+      return;
+    }
+
+    await entityManager.query(
+      `
+        WITH calculated_activity AS (
+          SELECT
+            target.id,
+            CASE
+              WHEN EXISTS (
+                SELECT 1
+                FROM task_assignees assignment
+                INNER JOIN tasks task ON task.id = assignment.task_id
+                INNER JOIN projects project ON project.id = task.project_id
+                WHERE assignment.member_id = target.id
+                  AND task.status::text IN ('in_progress', 'in_review')
+                  AND project.status::text = 'active'
+                  AND project.is_archived = FALSE
+              ) THEN 'active'
+              ELSE 'inactive'
+            END AS status
+          FROM members target
+          WHERE target.id = ANY($1::int[])
+        )
+        UPDATE members member
+        SET
+          activity_status = calculated_activity.status::members_activity_status_enum,
+          updated_at = CURRENT_TIMESTAMP
+        FROM calculated_activity
+        WHERE member.id = calculated_activity.id
+          AND member.activity_status::text <> calculated_activity.status;
+      `,
+      [uniqueMemberIds],
+    );
+  }
+
+  async refreshProjectMembers(
+    projectId: number,
+    entityManager: EntityManager = this.dataSource.manager,
+  ): Promise<void> {
+    const rows: { memberId: number | string }[] = await entityManager.query(
+      `
+        SELECT DISTINCT assignment.member_id AS "memberId"
+        FROM task_assignees assignment
+        INNER JOIN tasks task ON task.id = assignment.task_id
+        WHERE task.project_id = $1;
+      `,
+      [projectId],
+    );
+
+    await this.refreshMembers(
+      rows.map(({ memberId }) => Number(memberId)),
+      entityManager,
+    );
+  }
+}

--- a/apps/backend/src/members/member.entity.ts
+++ b/apps/backend/src/members/member.entity.ts
@@ -59,7 +59,7 @@ export class Member {
     name: 'activity_status',
     type: 'enum',
     enum: MemberActivityStatus,
-    default: MemberActivityStatus.ACTIVE,
+    default: MemberActivityStatus.INACTIVE,
   })
   activityStatus: MemberActivityStatus;
 

--- a/apps/backend/src/members/members.module.ts
+++ b/apps/backend/src/members/members.module.ts
@@ -6,6 +6,7 @@ import { AccessControlModule } from '../common/access-control.module';
 import { Skill } from '../skills/skill.entity';
 import { Member } from './member.entity';
 import { MembersController } from './members.controller';
+import { MemberActivityService } from './member-activity.service';
 import { MembersService } from './members.service';
 import { AuditModule } from '../audit/audit.module';
 
@@ -16,7 +17,7 @@ import { AuditModule } from '../audit/audit.module';
     AuditModule,
   ],
   controllers: [MembersController],
-  providers: [MembersService],
-  exports: [MembersService],
+  providers: [MemberActivityService, MembersService],
+  exports: [MemberActivityService, MembersService],
 })
 export class MembersModule {}

--- a/apps/backend/src/members/members.service.spec.ts
+++ b/apps/backend/src/members/members.service.spec.ts
@@ -877,7 +877,6 @@ describe('MembersService', () => {
     it('deactivates a member for Presidencia with an exact full name', async () => {
       const deactivatedMember = {
         ...persistedAreaDirectiveMember,
-        activityStatus: MemberActivityStatus.INACTIVE,
         availabilityStatus: MemberAvailabilityStatus.DISABLED,
       };
       membersRepository.findOne?.mockResolvedValue(
@@ -897,7 +896,7 @@ describe('MembersService', () => {
       expect(membersRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 10,
-          activityStatus: MemberActivityStatus.INACTIVE,
+          activityStatus: MemberActivityStatus.ACTIVE,
           availabilityStatus: MemberAvailabilityStatus.DISABLED,
         }),
       );
@@ -911,7 +910,6 @@ describe('MembersService', () => {
       };
       const deactivatedMember = {
         ...member,
-        activityStatus: MemberActivityStatus.INACTIVE,
         availabilityStatus: MemberAvailabilityStatus.DISABLED,
       };
       membersRepository.findOne?.mockResolvedValue(member);

--- a/apps/backend/src/members/members.service.spec.ts
+++ b/apps/backend/src/members/members.service.spec.ts
@@ -608,42 +608,13 @@ describe('MembersService', () => {
       );
     });
 
-    it('successfully reactivates a member', async () => {
+    it('updates availability without changing derived activity', async () => {
       const updateDto = {
-        activityStatus: MemberActivityStatus.ACTIVE,
         availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
       };
-      const reactivatedMember = {
-        ...persistedAreaDirectiveMember,
-        activityStatus: MemberActivityStatus.ACTIVE,
-        availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
-      };
-
-      membersRepository.findOne?.mockResolvedValue(
-        persistedAreaDirectiveMember,
-      );
-      membersRepository.save?.mockResolvedValue(reactivatedMember);
-
-      await expect(service.update(10, updateDto)).resolves.toEqual(
-        reactivatedMember,
-      );
-      expect(membersRepository.findOne).toHaveBeenCalledWith({
-        where: { id: 10 },
-        relations: ['memberships'],
-      });
-      expect(membersRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          activityStatus: MemberActivityStatus.ACTIVE,
-          availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
-        }),
-      );
-    });
-
-    it('successfully updates a member activity status', async () => {
-      const updateDto = { activityStatus: MemberActivityStatus.INACTIVE };
       const updatedMember = {
         ...persistedAreaDirectiveMember,
-        activityStatus: MemberActivityStatus.INACTIVE,
+        availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
       };
 
       membersRepository.findOne?.mockResolvedValue(
@@ -660,7 +631,7 @@ describe('MembersService', () => {
       });
       expect(membersRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          activityStatus: MemberActivityStatus.INACTIVE,
+          availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
         }),
       );
     });

--- a/apps/backend/src/members/members.service.ts
+++ b/apps/backend/src/members/members.service.ts
@@ -142,7 +142,6 @@ export class MembersService {
       );
     }
     const {
-      activityStatus,
       availabilityStatus,
       status,
       areaId,
@@ -175,9 +174,6 @@ export class MembersService {
 
     if (skills !== undefined) {
       member.skills = await this.resolveSkills(skills, skillsRepository);
-    }
-    if (activityStatus !== undefined) {
-      member.activityStatus = activityStatus;
     }
     if (resolvedAvailabilityStatus !== undefined) {
       member.availabilityStatus = resolvedAvailabilityStatus;

--- a/apps/backend/src/members/members.service.ts
+++ b/apps/backend/src/members/members.service.ts
@@ -24,7 +24,6 @@ import { CreateMemberDto } from './dto/create-member.dto';
 import { GetMembersFilterDto } from './dto/get-members-filter.dto';
 import { MemberResponse } from './dto/member-response.dto';
 import { UpdateMemberDto } from './dto/update-member.dto';
-import { MemberActivityStatus } from './enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from './enums/member-availability-status.enum';
 import { Member } from './member.entity';
 import { toMemberResponse } from './utils/member-response.util';
@@ -286,7 +285,6 @@ export class MembersService {
       );
     }
 
-    member.activityStatus = MemberActivityStatus.INACTIVE;
     member.availabilityStatus = MemberAvailabilityStatus.DISABLED;
 
     const savedMember = await this.membersRepository.save(member);

--- a/apps/backend/src/migrations/1787788800004-DeriveMemberActivityFromTasks.spec.ts
+++ b/apps/backend/src/migrations/1787788800004-DeriveMemberActivityFromTasks.spec.ts
@@ -1,0 +1,43 @@
+import { DeriveMemberActivityFromTasks1787788800004 } from './1787788800004-DeriveMemberActivityFromTasks';
+
+describe('DeriveMemberActivityFromTasks1787788800004', () => {
+  it('sets the inactive default and backfills activity from active projects', async () => {
+    const queries: string[] = [];
+    const queryRunner = {
+      query: jest.fn((sql: string) => {
+        queries.push(sql.replace(/\s+/g, ' ').trim());
+        if (sql.includes('SELECT COUNT(*)')) {
+          return Promise.resolve([{ count: 4 }]);
+        }
+        return Promise.resolve([]);
+      }),
+    };
+
+    await new DeriveMemberActivityFromTasks1787788800004().up(
+      queryRunner as never,
+    );
+
+    expect(queries).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("SET DEFAULT 'inactive'"),
+        expect.stringContaining(
+          "task.status::text IN ('in_progress', 'in_review')",
+        ),
+        expect.stringContaining("project.status::text = 'active'"),
+        expect.stringContaining('project.is_archived = FALSE'),
+      ]),
+    );
+  });
+
+  it('leaves fresh databases for TypeORM synchronization', async () => {
+    const queryRunner = {
+      query: jest.fn().mockResolvedValue([{ count: 0 }]),
+    };
+
+    await new DeriveMemberActivityFromTasks1787788800004().up(
+      queryRunner as never,
+    );
+
+    expect(queryRunner.query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/migrations/1787788800004-DeriveMemberActivityFromTasks.ts
+++ b/apps/backend/src/migrations/1787788800004-DeriveMemberActivityFromTasks.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeriveMemberActivityFromTasks1787788800004 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const requiredTables = (await queryRunner.query(`
+      SELECT COUNT(*)::int AS count
+      FROM information_schema.tables
+      WHERE table_schema = current_schema()
+        AND table_name IN ('members', 'projects', 'tasks', 'task_assignees');
+    `)) as { count: number }[];
+
+    // On a fresh database TypeORM synchronization creates the full schema.
+    if (Number(requiredTables[0]?.count) !== 4) {
+      return;
+    }
+
+    await queryRunner.query(`
+      ALTER TABLE members
+      ALTER COLUMN activity_status
+      SET DEFAULT 'inactive'::members_activity_status_enum;
+    `);
+
+    await queryRunner.query(`
+      UPDATE members member
+      SET activity_status = CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM task_assignees assignment
+          INNER JOIN tasks task ON task.id = assignment.task_id
+          INNER JOIN projects project ON project.id = task.project_id
+          WHERE assignment.member_id = member.id
+            AND task.status::text IN ('in_progress', 'in_review')
+            AND project.status::text = 'active'
+            AND project.is_archived = FALSE
+        ) THEN 'active'::members_activity_status_enum
+        ELSE 'inactive'::members_activity_status_enum
+      END;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const hasMembersTable = await queryRunner.hasTable('members');
+    if (!hasMembersTable) {
+      return;
+    }
+
+    await queryRunner.query(`
+      ALTER TABLE members
+      ALTER COLUMN activity_status
+      SET DEFAULT 'active'::members_activity_status_enum;
+    `);
+  }
+}

--- a/apps/backend/src/projects/projects.module.ts
+++ b/apps/backend/src/projects/projects.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AreaModule } from '../area/area.module';
 import { Member } from '../members/member.entity';
+import { MembersModule } from '../members/members.module';
 import { ProjectLabel } from './entities/project-label.entity';
 import { ProjectLink } from './entities/project-link.entity';
 import { ProjectMembership } from './entities/project-membership.entity';
@@ -15,6 +16,7 @@ import { AuditModule } from '../audit/audit.module';
 @Module({
   imports: [
     AreaModule,
+    MembersModule,
     TypeOrmModule.forFeature([
       Project,
       ProjectPhase,

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -22,6 +22,7 @@ import { ProjectRole } from '../common/enums/project-role.enum';
 import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { AreaMembership } from '../area-memberships/entities/area-membership.entity';
 import { Member } from '../members/member.entity';
+import { MemberActivityService } from '../members/member-activity.service';
 import { MemberActivityStatus } from '../members/enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from '../members/enums/member-availability-status.enum';
 import { DEFAULT_PROJECT_PHASES } from './constants/default-project-phases.constant';
@@ -339,6 +340,13 @@ describe('ProjectsService', () => {
           useValue: {
             record: jest.fn(),
             findAll: jest.fn(),
+          },
+        },
+        {
+          provide: MemberActivityService,
+          useValue: {
+            refreshMembers: jest.fn(),
+            refreshProjectMembers: jest.fn(),
           },
         },
       ],

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -23,6 +23,7 @@ import { parseAreaId } from '../common/utils/parse-area-id.util';
 import { MemberAvailabilityStatus } from '../members/enums/member-availability-status.enum';
 import { MemberActivityStatus } from '../members/enums/member-activity-status.enum';
 import { Member } from '../members/member.entity';
+import { MemberActivityService } from '../members/member-activity.service';
 import { DEFAULT_PROJECT_PHASES } from './constants/default-project-phases.constant';
 import { AddProjectMemberDto } from './dto/add-project-member.dto';
 import { CreateProjectPhaseDto } from './dto/create-project-phase.dto';
@@ -61,6 +62,7 @@ export class ProjectsService {
     private readonly taskAssigneesRepository: Repository<TaskAssignee>,
     private readonly areaService: AreaService,
     private readonly auditService: AuditService,
+    private readonly memberActivityService: MemberActivityService,
   ) {}
 
   async create(
@@ -270,6 +272,13 @@ export class ProjectsService {
 
       const savedProject = await projectsRepository.save(project);
 
+      if (updateProjectDto.status !== undefined) {
+        await this.memberActivityService.refreshProjectMembers(
+          savedProject.id,
+          entityManager,
+        );
+      }
+
       if (updateProjectDto.links !== undefined) {
         await this.replaceLinks(
           project,
@@ -298,21 +307,35 @@ export class ProjectsService {
   }
 
   async archive(id: number, accessActor: RequestAccessActor): Promise<Project> {
-    const project = await this.findProjectDetails(id);
-    this.assertProjectManagementAccess(project, accessActor);
-    project.isArchived = true;
+    await this.projectsRepository.manager.transaction(async (entityManager) => {
+      const projectsRepository = entityManager.getRepository(Project);
+      const project = await this.findProjectForUpdate(
+        id,
+        projectsRepository,
+        accessActor,
+      );
+      project.isArchived = true;
 
-    const savedProject = await this.projectsRepository.save(project);
+      const savedProject = await projectsRepository.save(project);
+      await this.memberActivityService.refreshProjectMembers(
+        savedProject.id,
+        entityManager,
+      );
 
-    await this.auditService.record(accessActor, {
-      action: 'archive',
-      entityType: 'Project',
-      entityId: savedProject.id,
-      areaId: savedProject.areaId,
-      metadata: { name: savedProject.name },
+      await this.auditService.record(
+        accessActor,
+        {
+          action: 'archive',
+          entityType: 'Project',
+          entityId: savedProject.id,
+          areaId: savedProject.areaId,
+          metadata: { name: savedProject.name },
+        },
+        entityManager,
+      );
     });
 
-    return savedProject;
+    return this.findOne(id, accessActor);
   }
 
   async findPhases(
@@ -976,11 +999,10 @@ export class ProjectsService {
         return;
       }
 
-      const { id, firstNames, lastNames, activityStatus, availabilityStatus } =
+      const { id, firstNames, lastNames, availabilityStatus } =
         membership.member;
 
       const isEligible =
-        activityStatus === MemberActivityStatus.ACTIVE &&
         availabilityStatus === MemberAvailabilityStatus.AVAILABLE;
 
       membership.member = {

--- a/apps/backend/src/tasks/tasks.module.ts
+++ b/apps/backend/src/tasks/tasks.module.ts
@@ -11,10 +11,12 @@ import { Task } from './entities/task.entity';
 import { TasksController } from './tasks.controller';
 import { TasksService } from './tasks.service';
 import { AuditModule } from '../audit/audit.module';
+import { MembersModule } from '../members/members.module';
 
 @Module({
   imports: [
     AccessControlModule,
+    MembersModule,
     TypeOrmModule.forFeature([
       Task,
       TaskAssignee,

--- a/apps/backend/src/tasks/tasks.service.spec.ts
+++ b/apps/backend/src/tasks/tasks.service.spec.ts
@@ -9,6 +9,7 @@ import { RequestAccessActor } from '../common/interfaces/request-access-actor.in
 import { MemberActivityStatus } from '../members/enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from '../members/enums/member-availability-status.enum';
 import { Member } from '../members/member.entity';
+import { MemberActivityService } from '../members/member-activity.service';
 import { ProjectMembership } from '../projects/entities/project-membership.entity';
 import { ProjectPhase } from '../projects/entities/project-phase.entity';
 import { Project } from '../projects/entities/project.entity';
@@ -251,6 +252,13 @@ describe('TasksService', () => {
           useValue: {
             record: jest.fn(),
             findAll: jest.fn(),
+          },
+        },
+        {
+          provide: MemberActivityService,
+          useValue: {
+            refreshMembers: jest.fn(),
+            refreshProjectMembers: jest.fn(),
           },
         },
       ],

--- a/apps/backend/src/tasks/tasks.service.ts
+++ b/apps/backend/src/tasks/tasks.service.ts
@@ -10,8 +10,8 @@ import { AreaRole } from '../common/enums/area-role.enum';
 import { ProjectRole } from '../common/enums/project-role.enum';
 import { PaginatedResponse } from '../common/interfaces/paginated-response.interface';
 import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
-import { MemberActivityStatus } from '../members/enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from '../members/enums/member-availability-status.enum';
+import { MemberActivityService } from '../members/member-activity.service';
 import { Member } from '../members/member.entity';
 import { ProjectMembership } from '../projects/entities/project-membership.entity';
 import { ProjectPhase } from '../projects/entities/project-phase.entity';
@@ -57,6 +57,7 @@ export class TasksService {
     @InjectRepository(ProjectMembership)
     private readonly projectMembershipsRepository: Repository<ProjectMembership>,
     private readonly auditService: AuditService,
+    private readonly memberActivityService: MemberActivityService,
   ) {}
 
   async create(
@@ -122,6 +123,10 @@ export class TasksService {
         );
 
         await taskAssigneesRepository.save(assignees);
+        await this.memberActivityService.refreshMembers(
+          memberships.map((membership) => membership.memberId),
+          entityManager,
+        );
 
         if (accessActor) {
           await this.auditService.record(
@@ -308,6 +313,7 @@ export class TasksService {
         entityManager.getRepository(ProjectMembership);
       const taskStatusHistoryRepository =
         entityManager.getRepository(TaskStatusHistory);
+      const taskAssigneesRepository = entityManager.getRepository(TaskAssignee);
       const task = await this.findTaskForUpdate(id, tasksRepository);
       const project = await this.findProjectOrThrow(
         task.projectId,
@@ -340,6 +346,13 @@ export class TasksService {
           newStatus: updateTaskStatusDto.status,
           actorId: this.getActorMemberId(accessActor),
         }),
+      );
+      const assignees = await taskAssigneesRepository.find({
+        where: { taskId: task.id },
+      });
+      await this.memberActivityService.refreshMembers(
+        assignees.map((assignee) => assignee.memberId),
+        entityManager,
       );
 
       if (accessActor) {
@@ -451,6 +464,10 @@ export class TasksService {
         projectMembershipsRepository,
       );
 
+      const previousAssignees = await taskAssigneesRepository.find({
+        where: { taskId: task.id },
+      });
+
       await taskAssigneesRepository.delete({ taskId: task.id });
       await taskAssigneesRepository.save(
         memberships.map((membership) =>
@@ -460,6 +477,13 @@ export class TasksService {
             projectMembershipId: membership.id,
           }),
         ),
+      );
+      await this.memberActivityService.refreshMembers(
+        [
+          ...previousAssignees.map((assignee) => assignee.memberId),
+          ...memberships.map((membership) => membership.memberId),
+        ],
+        entityManager,
       );
 
       if (accessActor) {
@@ -612,7 +636,6 @@ export class TasksService {
 
     const ineligibleMembership = memberships.find(
       ({ member }) =>
-        member.activityStatus !== MemberActivityStatus.ACTIVE ||
         member.availabilityStatus !== MemberAvailabilityStatus.AVAILABLE,
     );
 

--- a/apps/frontend/src/app/people-management/member-form.tsx
+++ b/apps/frontend/src/app/people-management/member-form.tsx
@@ -3,7 +3,7 @@
 import { FormEvent, useState } from "react";
 import { authorizedJson } from "@/lib/auth-client";
 import type { ManagedArea, ManagedMember } from "../people-management.types";
-import { Feedback, fieldClass, labelClass, messageFrom, Modal, primaryButton, secondaryButton } from "./shared";
+import { Feedback, fieldClass, labelClass, messageFrom, Modal, primaryButton, secondaryButton, statusLabels } from "./shared";
 
 type MemberFormState = {
   institution: string;
@@ -15,7 +15,6 @@ type MemberFormState = {
   role: string;
   areaId: string;
   skills: string;
-  activityStatus: string;
   availabilityStatus: string;
   cycle: string;
 };
@@ -43,7 +42,6 @@ export function MemberForm({
     role: member?.role ?? "miembro",
     areaId: member?.areaId ? String(member.areaId) : "",
     skills: member?.skills?.map((skill) => skill.name).join(", ") ?? "",
-    activityStatus: member?.activityStatus ?? "active",
     availabilityStatus: member?.availabilityStatus ?? "available",
     cycle: member?.cycle ? String(member.cycle) : "",
   };
@@ -70,7 +68,6 @@ export function MemberForm({
         major: form.major.trim(),
         birthDate: form.birthDate || undefined,
         skills,
-        activityStatus: form.activityStatus,
         availabilityStatus: form.availabilityStatus,
         cycle: form.cycle ? Number(form.cycle) : member ? null : undefined,
         ...(!member
@@ -184,14 +181,10 @@ export function MemberForm({
           />
           <label className={labelClass}>
             Actividad
-            <select
-              value={form.activityStatus}
-              onChange={(event) => set("activityStatus", event.target.value)}
-              className={fieldClass}
-            >
-              <option value="active">Activo</option>
-              <option value="inactive">Inactivo</option>
-            </select>
+            <output className={`${fieldClass} cursor-not-allowed opacity-70`}>
+              {statusLabels[member?.activityStatus ?? "inactive"] ?? "Inactivo"}
+              {" · Calculado desde tareas activas"}
+            </output>
           </label>
           <label className={labelClass}>
             Disponibilidad

--- a/apps/frontend/src/app/people-management/profile.tsx
+++ b/apps/frontend/src/app/people-management/profile.tsx
@@ -127,7 +127,7 @@ export function MemberProfileManagementView({
               Editar perfil
             </button>
           )}
-          {canDeactivate && member.activityStatus !== "inactive" && (
+          {canDeactivate && member.availabilityStatus !== "disabled" && (
             <button
               type="button"
               className={`${dangerButton} mt-4 w-full bg-transparent py-3`}

--- a/apps/frontend/src/app/task-management.tsx
+++ b/apps/frontend/src/app/task-management.tsx
@@ -491,9 +491,7 @@ export default function TaskManagement({
         .filter((m) => projectMemberIds.has(m.id))
         .map((m) => ({
           ...m,
-          isEligible:
-            m.activityStatus === "active" &&
-            m.availabilityStatus === "available",
+          isEligible: m.availabilityStatus === "available",
         }));
     }
 
@@ -504,7 +502,7 @@ export default function TaskManagement({
     );
   }, [activeProjectDetails, selectedProject, allMembers]);
 
-  // Eligible members: active AND available
+  // Activity is derived from current work and does not gate assignment.
   const eligibleMembers = useMemo(() => {
     return projectMembers.filter((m) => m.isEligible !== false);
   }, [projectMembers]);

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -6,7 +6,7 @@ Fuente de verdad revisada: controllers, DTOs, enums y guards de `apps/backend/sr
 
 - `200`: consulta o actualización exitosa; `201`: creación exitosa; los métodos `void` pueden responder sin cuerpo.
 - `400`: parámetros enteros inválidos o body/query que no cumple el DTO. La `ValidationPipe` transforma valores y elimina propiedades no declaradas.
-- `401`: token ausente, inválido, expirado o revocado; cuenta inactiva/deshabilitada; credenciales o secreto de bootstrap inválidos.
+- `401`: token ausente, inválido, expirado o revocado; cuenta deshabilitada; credenciales o secreto de bootstrap inválidos.
 - `403`: rol o alcance de área/proyecto insuficiente.
 - `404`: recurso relacionado inexistente.
 - `409`: unicidad, estado o regla de negocio en conflicto.
@@ -42,10 +42,10 @@ Fuente de verdad revisada: controllers, DTOs, enums y guards de `apps/backend/sr
 
 | Método y ruta | Auth / roles | Entrada | Respuesta | Errores y reglas de negocio |
 | :--- | :--- | :--- | :--- | :--- |
-| `POST /members` | `presidencia` | `{ institution?, studentCode?, firstNames, lastNames, major, birthDate, role?, areaId?, skills: string[], activityStatus?, availabilityStatus?, cycle? }` | `MemberResponse` (`201`) | Habilidades se normalizan a minúsculas; valida unicidad institución/código y asignación de rol/área. |
+| `POST /members` | `presidencia` | `{ institution?, studentCode?, firstNames, lastNames, major, birthDate, role?, areaId?, skills: string[], availabilityStatus?, cycle? }` | `MemberResponse` (`201`) | Habilidades se normalizan a minúsculas; valida unicidad institución/código y asignación de rol/área. La actividad se calcula a partir de las tareas del miembro. |
 | `GET /members` | `presidencia`, `directiva_de_area` | Query `activityStatus?`, `availabilityStatus?`, `areaId?`, `cycle?`, `skills?` repetible | `MemberResponse[]` | Directiva recibe solo miembros accesibles en su área. |
 | `PATCH /members/:id` | `presidencia` | Body parcial de datos del miembro; `skills` son nombres, no IDs | `MemberResponse` | No modifica el rol directamente; la membresía controla roles. |
-| `PATCH /members/:id/deactivate` | `presidencia`, `directiva_de_area` | `{ confirmName }` | `MemberResponse` con `activityStatus: "inactive"` | El texto debe ser exactamente `firstNames + " " + lastNames`; Directiva queda limitada a su área. |
+| `PATCH /members/:id/deactivate` | `presidencia`, `directiva_de_area` | `{ confirmName }` | `MemberResponse` con `availabilityStatus: "disabled"` | El texto debe ser exactamente `firstNames + " " + lastNames`; Directiva queda limitada a su área y la actividad calculada se conserva. |
 
 ### Habilidades no expuestas
 


### PR DESCRIPTION
## Summary

Implements automatic member activity calculation based on task assignments in active projects. Member activity is now derived by the system instead of being manually managed.

## Related Issue / Requirement

- Issue: UNI2-46
- GitHub Issue: N/A
- Requirements:
  - Mark a member as active when assigned to an `in_progress` or `in_review` task in an active, non-archived project.
  - Mark the member as inactive in every other case.
  - Recalculate activity after task status, assignee, project status, or project archival changes.
  - Prevent manual activity status updates.

## What Changed

- Added / Updated:
  - Added `MemberActivityService` to calculate and persist derived member activity.
  - Added a migration to set the default activity to `inactive` and backfill existing members.
  - Recalculated affected members when task assignees or task statuses change.
  - Recalculated project members when a project changes status or is archived.
  - Removed `activityStatus` from member creation and update DTOs.
- Backend / Frontend support for:
  - Removed activity as a prerequisite for task assignment, since assigning active work is what makes a member active.
  - Replaced the editable activity selector with a read-only calculated value.
  - Preserved availability as an independently managed status.

## How to Test

From the repository root:

- Run `npm run type-check -w frontend`
- Run `npm run lint -w frontend`
- Run `npm run test -w frontend`
- Run `npm run build -w frontend`
- Run `npm run type-check -w backend`
- Run `npm run lint -w backend`
- Run `npm run test -w backend`
- Run `npm run build -w backend`

Focused backend tests:

- Run `npm test -- --runInBand src/members/member-activity.service.spec.ts src/members/members.service.spec.ts src/tasks/tasks.service.spec.ts src/projects/projects.service.spec.ts src/migrations/1787788800004-DeriveMemberActivityFromTasks.spec.ts` from `apps/backend`.

Manual checks:

- Create a member and verify their initial activity is `inactive`.
- Assign the member to a `todo` task and verify they remain inactive.
- Move the task to `in_progress` or `in_review` in an active project and verify the member becomes active.
- Move the task to `done` or remove the member from the task and verify activity is recalculated.
- Pause, complete, or archive the project and verify its tasks no longer make members active.
- Verify activity is displayed as calculated and cannot be edited manually.
- Verify inactive but available members can still be assigned to tasks.

## Screenshots / Evidence

Local verification:

- Frontend type-check: OK.
- Frontend lint: OK.
- Frontend tests: 20/20 passed.
- Frontend build: OK.
- Backend type-check: OK.
- Backend lint for UNI2-46 files: OK.
- Backend tests: 284/284 passed.
- Backend build: OK.
- Focused backend tests: 99/99 passed.
- Migration unit tests: OK.
- Migration integration test: skipped because no test database was configured.

> Note: the complete backend lint command currently reports unrelated errors in the uncommitted `src/seed.ts` file. All files included in this PR pass ESLint.