### PR TITLE
Uni2 42 feataccess allow directiva to add members to own area

### DIFF
--- a/apps/backend/src/members/members.controller.spec.ts
+++ b/apps/backend/src/members/members.controller.spec.ts
@@ -4,7 +4,6 @@ import { DataSource } from 'typeorm';
 import { ROLES_KEY } from '../common/decorators/roles.decorator';
 import { AreaRole } from '../common/enums/area-role.enum';
 import { RolesGuard } from '../common/guards/roles.guard';
-import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { MemberActivityStatus } from './enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from './enums/member-availability-status.enum';
 import { Member } from './member.entity';
@@ -60,6 +59,7 @@ describe('MembersController', () => {
   });
 
   it('creates members through the service', async () => {
+    const accessActor = { role: AreaRole.PRESIDENCIA };
     const createdMember = {
       id: 1,
       institution: 'UNI',
@@ -94,15 +94,12 @@ describe('MembersController', () => {
     mockMembersService.create.mockResolvedValue(createdMember);
 
     await expect(
-      controller.create(
-        createMemberDto,
-        undefined as unknown as RequestAccessActor,
-      ),
+      controller.create(createMemberDto, accessActor),
     ).resolves.toEqual(toMemberResponse(createdMember, AreaRole.PRESIDENCIA));
     expect(mockMembersService.create).toHaveBeenCalledWith(
       createMemberDto,
       undefined,
-      undefined,
+      accessActor,
     );
   });
 
@@ -156,10 +153,10 @@ describe('MembersController', () => {
       expect(guards).toContain(RolesGuard);
     });
 
-    it('guards member creation for Presidencia only', () => {
+    it('guards member creation for Presidencia and Directiva de Area', () => {
       expect(
         Reflect.getMetadata(ROLES_KEY, getMembersControllerMethod('create')),
-      ).toEqual([AreaRole.PRESIDENCIA]);
+      ).toEqual([AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA]);
     });
 
     it('guards member listing for Presidencia and Directiva de Area', () => {

--- a/apps/backend/src/members/members.controller.ts
+++ b/apps/backend/src/members/members.controller.ts
@@ -28,17 +28,17 @@ export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 
   @Post()
-  @Roles(AreaRole.PRESIDENCIA)
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
   async create(
     @Body() createMemberDto: CreateMemberDto,
-    @CurrentAccessActor() accessActor?: RequestAccessActor,
+    @CurrentAccessActor() accessActor: RequestAccessActor,
   ): Promise<MemberResponse> {
     const member = await this.membersService.create(
       createMemberDto,
       undefined,
       accessActor,
     );
-    return toMemberResponse(member, AreaRole.PRESIDENCIA);
+    return toMemberResponse(member, accessActor.role);
   }
 
   @Get()

--- a/apps/backend/src/members/members.service.spec.ts
+++ b/apps/backend/src/members/members.service.spec.ts
@@ -324,6 +324,56 @@ describe('MembersService', () => {
     });
   });
 
+  it('allows Directiva to create a regular member in its own area', async () => {
+    const createDto = {
+      ...areaDirectiveMemberDto,
+      role: AreaRole.MIEMBRO,
+    };
+    const accessActor: RequestAccessActor = {
+      role: AreaRole.DIRECTIVA_DE_AREA,
+      areaId: '3',
+    };
+
+    areasRepository.exists?.mockResolvedValue(true);
+    skillsRepository.find?.mockResolvedValue(persistedSkills);
+    membersRepository.create?.mockReturnValue(persistedAreaDirectiveMember);
+    membersRepository.save?.mockResolvedValue(persistedAreaDirectiveMember);
+
+    await expect(
+      service.create(createDto, undefined, accessActor),
+    ).resolves.toEqual(persistedAreaDirectiveMember);
+    expect(areaMembershipsRepository.create).toHaveBeenCalledWith({
+      member: persistedAreaDirectiveMember,
+      area: { id: 3 },
+      role: AreaRole.MIEMBRO,
+    });
+  });
+
+  it('rejects Directiva member creation in another area', async () => {
+    const accessActor: RequestAccessActor = {
+      role: AreaRole.DIRECTIVA_DE_AREA,
+      areaId: '2',
+    };
+
+    await expect(
+      service.create(areaDirectiveMemberDto, undefined, accessActor),
+    ).rejects.toThrow(ForbiddenException);
+    expect(areasRepository.exists).not.toHaveBeenCalled();
+    expect(membersRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects privileged role creation by Directiva in its own area', async () => {
+    const accessActor: RequestAccessActor = {
+      role: AreaRole.DIRECTIVA_DE_AREA,
+      areaId: '3',
+    };
+
+    await expect(
+      service.create(areaDirectiveMemberDto, undefined, accessActor),
+    ).rejects.toThrow(ForbiddenException);
+    expect(membersRepository.create).not.toHaveBeenCalled();
+  });
+
   it('supports legacy status input mapping to availabilityStatus when creating a member', async () => {
     const externalSkills: Skill[] = [createSkill(3, 'facilitacion')];
     const createDto = {

--- a/apps/backend/src/members/members.service.ts
+++ b/apps/backend/src/members/members.service.ts
@@ -58,6 +58,8 @@ export class MembersService {
     entityManager?: EntityManager,
     accessActor?: RequestAccessActor,
   ): Promise<Member> {
+    this.assertMemberCreationAccess(createMemberDto, accessActor);
+
     if (!entityManager) {
       return this.dataSource.transaction(async (em) =>
         this.create(createMemberDto, em, accessActor),
@@ -462,6 +464,29 @@ export class MembersService {
 
     throw new ForbiddenException(
       'Member deactivation is limited to members in your own area',
+    );
+  }
+
+  private assertMemberCreationAccess(
+    createMemberDto: CreateMemberDto,
+    accessActor?: RequestAccessActor,
+  ): void {
+    if (!accessActor || accessActor.role === AreaRole.PRESIDENCIA) {
+      return;
+    }
+
+    if (accessActor.role === AreaRole.DIRECTIVA_DE_AREA) {
+      const actorAreaId = parseAreaId(accessActor.areaId);
+      if (
+        createMemberDto.areaId === actorAreaId &&
+        createMemberDto.role === AreaRole.MIEMBRO
+      ) {
+        return;
+      }
+    }
+
+    throw new ForbiddenException(
+      'Member creation is limited to regular members in your own area',
     );
   }
 }

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -33,7 +33,14 @@ import {
   getMemberAreaIds,
   navItems,
 } from "./dashboard.model";
-import { DashboardView, Logo, NavButton, PlaceholderView, ProfileView, SessionLoadingView } from "./dashboard.components";
+import {
+  DashboardView,
+  Logo,
+  NavButton,
+  PlaceholderView,
+  ProfileView,
+  SessionLoadingView,
+} from "./dashboard.components";
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -326,9 +333,9 @@ export default function DashboardPage() {
                 metric={selectedArea}
                 accessToken={accessToken}
                 currentRole={currentMember.role}
+                currentAreaId={currentMember.areaId}
                 onChanged={refreshPeopleData}
                 onBack={() => setView("areas")}
-                onGoToMembers={() => setView("members")}
                 onOpenMember={(memberId) => {
                   setSelectedMemberId(memberId);
                   setView("member-profile");

--- a/apps/frontend/src/app/people-management-utils.test.ts
+++ b/apps/frontend/src/app/people-management-utils.test.ts
@@ -1,10 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  canCreateMemberInArea,
   filterAndSortMembers,
   getProjectLabelsForMember,
   type MemberDirectoryFilters,
 } from "./people-management-utils";
+
+test("allows member creation only for Presidencia or the area's Directiva", () => {
+  assert.equal(canCreateMemberInArea("presidencia", null, 10), true);
+  assert.equal(canCreateMemberInArea("directiva_de_area", 10, 10), true);
+  assert.equal(canCreateMemberInArea("directiva_de_area", 20, 10), false);
+  assert.equal(canCreateMemberInArea("miembro", 10, 10), false);
+});
 
 const members = [
   {

--- a/apps/frontend/src/app/people-management-utils.test.ts
+++ b/apps/frontend/src/app/people-management-utils.test.ts
@@ -12,6 +12,11 @@ test("allows member creation only for Presidencia or the area's Directiva", () =
   assert.equal(canCreateMemberInArea("directiva_de_area", 10, 10), true);
   assert.equal(canCreateMemberInArea("directiva_de_area", 20, 10), false);
   assert.equal(canCreateMemberInArea("miembro", 10, 10), false);
+  assert.equal(canCreateMemberInArea("presidencia", null, 10, true), false);
+  assert.equal(
+    canCreateMemberInArea("directiva_de_area", 10, 10, true),
+    false,
+  );
 });
 
 const members = [

--- a/apps/frontend/src/app/people-management-utils.ts
+++ b/apps/frontend/src/app/people-management-utils.ts
@@ -33,7 +33,10 @@ export function canCreateMemberInArea(
   role: string,
   actorAreaId: number | null | undefined,
   targetAreaId: number,
+  isArchived = false,
 ): boolean {
+  if (isArchived) return false;
+
   return (
     role === "presidencia" ||
     (role === "directiva_de_area" && actorAreaId === targetAreaId)

--- a/apps/frontend/src/app/people-management-utils.ts
+++ b/apps/frontend/src/app/people-management-utils.ts
@@ -29,6 +29,17 @@ function normalize(value: string): string {
   return value.trim().toLocaleLowerCase("es");
 }
 
+export function canCreateMemberInArea(
+  role: string,
+  actorAreaId: number | null | undefined,
+  targetAreaId: number,
+): boolean {
+  return (
+    role === "presidencia" ||
+    (role === "directiva_de_area" && actorAreaId === targetAreaId)
+  );
+}
+
 export function getProjectLabelsForMember(
   memberId: number,
   projects: ProjectDirectoryItem[],

--- a/apps/frontend/src/app/people-management/areas.tsx
+++ b/apps/frontend/src/app/people-management/areas.tsx
@@ -3,8 +3,18 @@
 import Image from "next/image";
 import { useState } from "react";
 import type { AreaMetric, ManagedArea } from "../people-management.types";
-import { fieldClass, primaryButton, secondaryButton, dangerButton, StatusPill, PageHeading, SearchField } from "./shared";
+import { canCreateMemberInArea } from "../people-management-utils";
+import {
+  fieldClass,
+  primaryButton,
+  secondaryButton,
+  dangerButton,
+  StatusPill,
+  PageHeading,
+  SearchField,
+} from "./shared";
 import { MemberTable } from "./members";
+import { MemberForm } from "./member-form";
 
 import { AreaForm, ExactNameAction } from "./area-actions";
 export { ExactNameAction } from "./area-actions";
@@ -224,22 +234,28 @@ export function AreaDetailManagementView({
   metric,
   accessToken,
   currentRole,
+  currentAreaId,
   onBack,
   onOpenMember,
-  onGoToMembers,
   onChanged,
 }: {
   metric: AreaMetric;
   accessToken: string;
   currentRole: string;
+  currentAreaId?: number | null;
   onBack: () => void;
   onOpenMember: (memberId: number) => void;
-  onGoToMembers: () => void;
   onChanged: () => Promise<void>;
 }) {
   const [editing, setEditing] = useState(false);
   const [archiving, setArchiving] = useState(false);
+  const [creatingMember, setCreatingMember] = useState(false);
   const canEdit = currentRole === "presidencia";
+  const canAddMember = canCreateMemberInArea(
+    currentRole,
+    currentAreaId,
+    metric.area.id,
+  );
   return (
     <div>
       <button
@@ -289,11 +305,11 @@ export function AreaDetailManagementView({
       <section className="rounded-md border border-white/8 bg-[#191822] p-5 sm:p-8">
         <div className="mb-6 flex items-center justify-between">
           <h2 className="text-xl font-black">Miembros</h2>
-          {canEdit && (
+          {canAddMember && (
             <button
               type="button"
               className={primaryButton}
-              onClick={onGoToMembers}
+              onClick={() => setCreatingMember(true)}
             >
               ＋ Añadir miembro
             </button>
@@ -328,6 +344,19 @@ export function AreaDetailManagementView({
           onDone={async () => {
             setArchiving(false);
             onBack();
+            await onChanged();
+          }}
+        />
+      )}
+      {creatingMember && (
+        <MemberForm
+          areas={[metric.area]}
+          accessToken={accessToken}
+          fixedAreaId={metric.area.id}
+          regularMemberOnly={currentRole === "directiva_de_area"}
+          onClose={() => setCreatingMember(false)}
+          onSaved={async () => {
+            setCreatingMember(false);
             await onChanged();
           }}
         />

--- a/apps/frontend/src/app/people-management/areas.tsx
+++ b/apps/frontend/src/app/people-management/areas.tsx
@@ -255,6 +255,7 @@ export function AreaDetailManagementView({
     currentRole,
     currentAreaId,
     metric.area.id,
+    Boolean(metric.area.isArchived),
   );
   return (
     <div>

--- a/apps/frontend/src/app/people-management/member-form.tsx
+++ b/apps/frontend/src/app/people-management/member-form.tsx
@@ -3,7 +3,15 @@
 import { FormEvent, useState } from "react";
 import { authorizedJson } from "@/lib/auth-client";
 import type { ManagedArea, ManagedMember } from "../people-management.types";
-import { Feedback, fieldClass, labelClass, messageFrom, Modal, primaryButton, secondaryButton } from "./shared";
+import {
+  Feedback,
+  fieldClass,
+  labelClass,
+  messageFrom,
+  Modal,
+  primaryButton,
+  secondaryButton,
+} from "./shared";
 
 type MemberFormState = {
   institution: string;
@@ -24,12 +32,16 @@ export function MemberForm({
   member,
   areas,
   accessToken,
+  fixedAreaId,
+  regularMemberOnly = false,
   onClose,
   onSaved,
 }: {
   member?: ManagedMember;
   areas: ManagedArea[];
   accessToken: string;
+  fixedAreaId?: number;
+  regularMemberOnly?: boolean;
   onClose: () => void;
   onSaved: (memberId: number) => Promise<void>;
 }) {
@@ -40,8 +52,12 @@ export function MemberForm({
     lastNames: member?.lastNames ?? "",
     major: member?.major ?? "",
     birthDate: member?.birthDate?.slice(0, 10) ?? "",
-    role: member?.role ?? "miembro",
-    areaId: member?.areaId ? String(member.areaId) : "",
+    role: regularMemberOnly ? "miembro" : (member?.role ?? "miembro"),
+    areaId: fixedAreaId
+      ? String(fixedAreaId)
+      : member?.areaId
+        ? String(member.areaId)
+        : "",
     skills: member?.skills?.map((skill) => skill.name).join(", ") ?? "",
     activityStatus: member?.activityStatus ?? "active",
     availabilityStatus: member?.availabilityStatus ?? "available",
@@ -147,6 +163,7 @@ export function MemberForm({
                 Rol
                 <select
                   value={form.role}
+                  disabled={regularMemberOnly}
                   onChange={(event) => set("role", event.target.value)}
                   className={fieldClass}
                 >
@@ -160,7 +177,7 @@ export function MemberForm({
                 <select
                   required={form.role === "directiva_de_area"}
                   value={form.areaId}
-                  disabled={form.role === "presidencia"}
+                  disabled={form.role === "presidencia" || Boolean(fixedAreaId)}
                   onChange={(event) => set("areaId", event.target.value)}
                   className={fieldClass}
                 >

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -42,7 +42,7 @@ Fuente de verdad revisada: controllers, DTOs, enums y guards de `apps/backend/sr
 
 | Método y ruta | Auth / roles | Entrada | Respuesta | Errores y reglas de negocio |
 | :--- | :--- | :--- | :--- | :--- |
-| `POST /members` | `presidencia` | `{ institution?, studentCode?, firstNames, lastNames, major, birthDate, role?, areaId?, skills: string[], activityStatus?, availabilityStatus?, cycle? }` | `MemberResponse` (`201`) | Habilidades se normalizan a minúsculas; valida unicidad institución/código y asignación de rol/área. |
+| `POST /members` | `presidencia`, `directiva_de_area` | `{ institution?, studentCode?, firstNames, lastNames, major, birthDate, role?, areaId?, skills: string[], activityStatus?, availabilityStatus?, cycle? }` | `MemberResponse` (`201`) | Habilidades se normalizan a minúsculas; valida unicidad institución/código y asignación de rol/área. Directiva solo puede crear el rol `miembro` dentro de su área autenticada. |
 | `GET /members` | `presidencia`, `directiva_de_area` | Query `activityStatus?`, `availabilityStatus?`, `areaId?`, `cycle?`, `skills?` repetible | `MemberResponse[]` | Directiva recibe solo miembros accesibles en su área. |
 | `PATCH /members/:id` | `presidencia` | Body parcial de datos del miembro; `skills` son nombres, no IDs | `MemberResponse` | No modifica el rol directamente; la membresía controla roles. |
 | `PATCH /members/:id/deactivate` | `presidencia`, `directiva_de_area` | `{ confirmName }` | `MemberResponse` con `activityStatus: "inactive"` | El texto debe ser exactamente `firstNames + " " + lastNames`; Directiva queda limitada a su área. |


### PR DESCRIPTION
## Summary

Allows Area Leadership users to create regular members directly from their own area while enforcing strict area isolation and preventing privilege escalation.

## Related Issue / Requirement

- Issue: UNI2-42
- GitHub Issue: feat(access): allow Directiva de Área to add members to its own area #63
- Requirements:
  - Allow Directiva de Área to create members only within its authenticated area.
  - Reject attempts to create members in another area through manipulated API requests.
  - Prevent Directiva de Área from creating privileged roles.
  - Keep Presidencia's global member creation behavior unchanged.
  - Create exactly one initial membership and retain audit recording.

## What Changed

- Added / Updated:
  - Allowed `POST /members` for Presidencia and Directiva de Área.
  - Added service-level authorization to validate the authenticated role and area.
  - Limited Directiva de Área to creating users with the `miembro` role.
  - Rejected missing, different, or manipulated area assignments.
  - Added backend tests for allowed and rejected creation scenarios.
- Backend / Frontend support for:
  - Displayed “Añadir miembro” inside an area owned by the authenticated Directiva.
  - Hid the action when viewing another area.
  - Opened the member form directly from the area detail page.
  - Automatically selected and locked the current area.
  - Restricted the role to `miembro` when Directiva creates the member.
  - Added frontend authorization tests for Presidencia, Directiva de Área, and Miembro.

## How to Test

From the repository root:

- Run `npm run type-check -w frontend`
- Run `npm run lint -w frontend`
- Run `npm run test -w frontend`
- Run `npm run build -w frontend`
- Run `npm run type-check -w backend`
- Run `npm run lint -w backend`
- Run `npm run test -w backend`
- Run `npm run build -w backend`

Focused backend tests:

- Run `npm test -- --runInBand src/members/members.service.spec.ts src/members/members.controller.spec.ts` from `apps/backend`.

Manual checks:

- Log in as Presidencia and verify global member creation remains available.
- Log in as Directiva de Área and open its own area.
- Verify “Añadir miembro” is visible and opens the member form directly.
- Verify the current area is automatically selected and cannot be changed.
- Verify the role is fixed to `miembro`.
- Create the member and verify exactly one initial membership exists in the current area.
- Verify the creation appears in the audit history.
- Attempt to send another `areaId` directly through the API and verify the request is rejected.
- Attempt to create a Directiva or Presidencia account through the API and verify the request is rejected.
- Verify Directiva does not see the action when viewing another area.
- Log in as Miembro and verify the action is not available.

## Screenshots / Evidence

Local verification:

- Frontend type-check: OK.
- Frontend lint: OK.
- Frontend tests: 21/21 passed.
- Frontend build: OK.
- Backend type-check: OK.
- Backend lint for UNI2-42 files: OK.
- Backend tests: 283/283 passed.
- Backend build: OK.
- Focused backend tests: 40/40 passed.

> Note: the complete backend lint command currently reports unrelated errors in the uncommitted `src/seed.ts` file. All files included in this PR pass ESLint.