### PR TITLE
fix(frontend): standardize application routes and deep-link navigation

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src next.config.ts postcss.config.mjs",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/frontend/src/app/dashboard/[...segments]/page.tsx
+++ b/apps/frontend/src/app/dashboard/[...segments]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../page";

--- a/apps/frontend/src/app/dashboard/dashboard-route.test.ts
+++ b/apps/frontend/src/app/dashboard/dashboard-route.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  canAccessDashboardRoute,
+  getDashboardPath,
+  getRouteNavView,
+  parseDashboardPath,
+} from "./dashboard-route";
+
+describe("dashboard canonical routes", () => {
+  it("maps list and detail paths to their views", () => {
+    assert.deepEqual(parseDashboardPath("/dashboard/areas"), { view: "areas" });
+    assert.deepEqual(parseDashboardPath("/dashboard/areas/42"), {
+      view: "area-detail",
+      resourceId: 42,
+    });
+    assert.deepEqual(parseDashboardPath("/dashboard/members/7/"), {
+      view: "member-profile",
+      resourceId: 7,
+    });
+  });
+
+  it("rejects invalid, duplicate, and incomplete paths", () => {
+    assert.deepEqual(parseDashboardPath("/dashboard/area/4"), {
+      view: "not-found",
+    });
+    assert.deepEqual(parseDashboardPath("/dashboard/members/0"), {
+      view: "not-found",
+    });
+    assert.deepEqual(parseDashboardPath("/dashboard/projects/3"), {
+      view: "not-found",
+    });
+  });
+
+  it("builds canonical paths for navigation", () => {
+    assert.equal(getDashboardPath("dashboard"), "/dashboard");
+    assert.equal(getDashboardPath("projects"), "/dashboard/projects");
+    assert.equal(getDashboardPath("area-detail", 12), "/dashboard/areas/12");
+    assert.equal(
+      getDashboardPath("member-profile", 15),
+      "/dashboard/members/15",
+    );
+  });
+
+  it("keeps detail routes active under their parent navigation item", () => {
+    assert.equal(
+      getRouteNavView({ view: "area-detail", resourceId: 2 }),
+      "areas",
+    );
+    assert.equal(
+      getRouteNavView({ view: "member-profile", resourceId: 9 }),
+      "members",
+    );
+  });
+
+  it("preserves people and audit authorization on direct navigation", () => {
+    const areaRoute = parseDashboardPath("/dashboard/areas/2");
+    assert.equal(canAccessDashboardRoute(areaRoute, "miembro"), false);
+    assert.equal(
+      canAccessDashboardRoute(areaRoute, "directiva_de_area"),
+      true,
+    );
+    assert.equal(
+      canAccessDashboardRoute(parseDashboardPath("/dashboard/tasks"), "miembro"),
+      true,
+    );
+  });
+});

--- a/apps/frontend/src/app/dashboard/dashboard-route.ts
+++ b/apps/frontend/src/app/dashboard/dashboard-route.ts
@@ -1,0 +1,82 @@
+import type { View } from "./dashboard.types";
+
+export type DashboardRoute = {
+  view: View | "not-found";
+  resourceId?: number;
+};
+
+const VIEW_PATHS: Record<Exclude<View, "area-detail" | "member-profile">, string> = {
+  dashboard: "/dashboard",
+  areas: "/dashboard/areas",
+  members: "/dashboard/members",
+  projects: "/dashboard/projects",
+  tasks: "/dashboard/tasks",
+  integrations: "/dashboard/integrations",
+  audit: "/dashboard/audit",
+  profile: "/dashboard/profile",
+};
+
+function parsePositiveId(value: string): number | undefined {
+  if (!/^\d+$/.test(value)) return undefined;
+  const id = Number(value);
+  return Number.isSafeInteger(id) && id > 0 ? id : undefined;
+}
+
+export function parseDashboardPath(pathname: string): DashboardRoute {
+  const normalizedPath = pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+
+  const staticRoute = Object.entries(VIEW_PATHS).find(
+    ([, path]) => path === normalizedPath,
+  );
+  if (staticRoute) return { view: staticRoute[0] as View };
+
+  const areaMatch = normalizedPath.match(/^\/dashboard\/areas\/([^/]+)$/);
+  if (areaMatch) {
+    const resourceId = parsePositiveId(areaMatch[1]);
+    return resourceId
+      ? { view: "area-detail", resourceId }
+      : { view: "not-found" };
+  }
+
+  const memberMatch = normalizedPath.match(/^\/dashboard\/members\/([^/]+)$/);
+  if (memberMatch) {
+    const resourceId = parsePositiveId(memberMatch[1]);
+    return resourceId
+      ? { view: "member-profile", resourceId }
+      : { view: "not-found" };
+  }
+
+  return { view: "not-found" };
+}
+
+export function getDashboardPath(view: View, resourceId?: number): string {
+  if (view === "area-detail") {
+    if (!resourceId) throw new Error("El detalle de área requiere un identificador");
+    return `/dashboard/areas/${resourceId}`;
+  }
+  if (view === "member-profile") {
+    if (!resourceId) throw new Error("El perfil de miembro requiere un identificador");
+    return `/dashboard/members/${resourceId}`;
+  }
+  return VIEW_PATHS[view];
+}
+
+export function getRouteNavView(route: DashboardRoute): View | undefined {
+  if (route.view === "area-detail") return "areas";
+  if (route.view === "member-profile") return "members";
+  return route.view === "not-found" ? undefined : route.view;
+}
+
+export function canAccessDashboardRoute(
+  route: DashboardRoute,
+  role?: string,
+): boolean {
+  const normalizedRole = role?.trim().toLowerCase();
+  const protectedView = getRouteNavView(route);
+  if (!protectedView || !["areas", "members", "audit"].includes(protectedView)) {
+    return true;
+  }
+  return (
+    normalizedRole === "presidencia" || normalizedRole === "directiva_de_area"
+  );
+}

--- a/apps/frontend/src/app/dashboard/dashboard.components.tsx
+++ b/apps/frontend/src/app/dashboard/dashboard.components.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import type { ReactNode } from "react";
 import { API_URL } from "@/lib/auth-client";
 import { fullName } from "./dashboard.model";
@@ -43,19 +44,19 @@ export function SessionLoadingView() {
 
 export function NavButton({
   active,
+  href,
   icon,
   label,
-  onClick,
 }: {
   active: boolean;
+  href: string;
   icon: string;
   label: string;
-  onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <Link
+      href={href}
+      aria-current={active ? "page" : undefined}
       className={`flex h-10 w-full items-center gap-5 rounded-md px-3 text-left text-[20px] font-medium outline-none transition ${
         active
           ? "bg-[#252633] text-white"
@@ -71,7 +72,7 @@ export function NavButton({
         aria-hidden
       />
       <span>{label}</span>
-    </button>
+    </Link>
   );
 }
 
@@ -312,6 +313,30 @@ export function PlaceholderView({ title }: { title: string }) {
           Dashboard, Áreas, Miembros y Proyectos.
         </p>
       </Panel>
+    </div>
+  );
+}
+
+export function RouteStateView({
+  title,
+  description,
+  href = "/dashboard",
+  action = "Volver al dashboard",
+}: {
+  title: string;
+  description: string;
+  href?: string;
+  action?: string;
+}) {
+  return (
+    <div>
+      <SectionTitle title={title} subtitle={description} />
+      <Link
+        href={href}
+        className="inline-flex rounded-md bg-[#4067c9] px-4 py-2.5 text-sm font-semibold hover:bg-[#5278d5]"
+      >
+        {action}
+      </Link>
     </div>
   );
 }

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import {
   ApiError,
@@ -33,19 +33,37 @@ import {
   getMemberAreaIds,
   navItems,
 } from "./dashboard.model";
-import { DashboardView, Logo, NavButton, PlaceholderView, ProfileView, SessionLoadingView } from "./dashboard.components";
+import {
+  canAccessDashboardRoute,
+  getDashboardPath,
+  getRouteNavView,
+  parseDashboardPath,
+} from "./dashboard-route";
+import {
+  DashboardView,
+  Logo,
+  NavButton,
+  PlaceholderView,
+  ProfileView,
+  RouteStateView,
+  SessionLoadingView,
+} from "./dashboard.components";
 
 export default function DashboardPage() {
   const router = useRouter();
+  const params = useParams<{ segments?: string[] }>();
+  const pathname = params.segments?.length
+    ? `/dashboard/${params.segments.join("/")}`
+    : "/dashboard";
+  const route = parseDashboardPath(pathname);
+  const view = route.view;
+  const activeNavView = getRouteNavView(route);
   const [authState, setAuthState] = useState<AuthState>("initializing");
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [currentMember, setCurrentMember] = useState<Member | null>(null);
-  const [view, setView] = useState<View>("dashboard");
   const [areas, setAreas] = useState<Area[]>([]);
   const [members, setMembers] = useState<Member[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
-  const [selectedAreaId, setSelectedAreaId] = useState<number | null>(null);
-  const [selectedMemberId, setSelectedMemberId] = useState<number | null>(null);
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [error, setError] = useState("");
   const currentMemberRole = currentMember?.role;
@@ -117,11 +135,7 @@ export default function DashboardPage() {
         if (ignore) return;
 
         setAreas(loadedAreas);
-        setSelectedAreaId((current) => current ?? loadedAreas[0]?.id ?? null);
         setMembers(loadedMembers);
-        setSelectedMemberId(
-          (current) => current ?? loadedMembers[0]?.id ?? null,
-        );
         setProjects(loadedProjects);
         setLoadState("ready");
       } catch (currentError) {
@@ -184,16 +198,6 @@ export default function DashboardPage() {
     setAreas(loadedAreas);
     setMembers(loadedMembers);
     setProjects(loadedProjects);
-    setSelectedAreaId((current) =>
-      loadedAreas.some((area) => area.id === current)
-        ? current
-        : (loadedAreas[0]?.id ?? null),
-    );
-    setSelectedMemberId((current) =>
-      loadedMembers.some((member) => member.id === current)
-        ? current
-        : (loadedMembers[0]?.id ?? null),
-    );
   };
 
   const areaMetrics = useMemo(
@@ -219,11 +223,14 @@ export default function DashboardPage() {
   );
 
   const selectedArea =
-    areaMetrics.find((metric) => metric.area.id === selectedAreaId) ??
-    areaMetrics[0];
+    route.view === "area-detail"
+      ? areaMetrics.find((metric) => metric.area.id === route.resourceId)
+      : undefined;
 
   const selectedMember =
-    members.find((member) => member.id === selectedMemberId) ?? members[0];
+    route.view === "member-profile"
+      ? members.find((member) => member.id === route.resourceId)
+      : undefined;
 
   const activeMembers = members.filter(
     (member) => member.activityStatus !== "inactive",
@@ -236,6 +243,8 @@ export default function DashboardPage() {
     return <SessionLoadingView />;
   }
 
+  const routeAuthorized = canAccessDashboardRoute(route, currentMember.role);
+
   return (
     <main className="min-h-screen bg-[#060610] text-white">
       <div className="flex min-h-screen">
@@ -245,10 +254,10 @@ export default function DashboardPage() {
             {visibleNavItems.map((item) => (
               <NavButton
                 key={item.id}
-                active={view === item.id}
+                active={activeNavView === item.id}
+                href={getDashboardPath(item.id)}
                 icon={item.icon}
                 label={item.label}
-                onClick={() => setView(item.id)}
               />
             ))}
           </nav>
@@ -272,8 +281,10 @@ export default function DashboardPage() {
             <Logo compact />
             <select
               aria-label="Cambiar vista"
-              value={view}
-              onChange={(event) => setView(event.target.value as View)}
+              value={activeNavView ?? "dashboard"}
+              onChange={(event) =>
+                router.push(getDashboardPath(event.target.value as View))
+              }
               className="rounded-md border border-white/10 bg-[#20212c] px-3 py-2 text-sm text-white"
             >
               {visibleNavItems.map((item) => (
@@ -298,7 +309,19 @@ export default function DashboardPage() {
               </div>
             )}
 
-            {view === "dashboard" && (
+            {view === "not-found" && (
+              <RouteStateView
+                title="Página no encontrada"
+                description="La dirección solicitada no corresponde a una vista disponible de UNICORE."
+              />
+            )}
+            {view !== "not-found" && !routeAuthorized && (
+              <RouteStateView
+                title="Acceso restringido"
+                description="Tu rol no tiene permisos para abrir esta vista."
+              />
+            )}
+            {view === "dashboard" && routeAuthorized && (
               <DashboardView
                 areaCount={areas.filter((area) => !area.isArchived).length}
                 memberCount={members.length}
@@ -309,33 +332,42 @@ export default function DashboardPage() {
                 authRole={currentMember.role}
               />
             )}
-            {view === "areas" && (
+            {view === "areas" && routeAuthorized && (
               <AreasManagementView
                 metrics={areaMetrics}
                 accessToken={accessToken}
                 currentRole={currentMember.role}
                 onChanged={refreshPeopleData}
                 onSelectArea={(areaId) => {
-                  setSelectedAreaId(areaId);
-                  setView("area-detail");
+                  router.push(getDashboardPath("area-detail", areaId));
                 }}
               />
             )}
-            {view === "area-detail" && selectedArea && (
+            {view === "area-detail" && routeAuthorized && selectedArea && (
               <AreaDetailManagementView
                 metric={selectedArea}
                 accessToken={accessToken}
                 currentRole={currentMember.role}
                 onChanged={refreshPeopleData}
-                onBack={() => setView("areas")}
-                onGoToMembers={() => setView("members")}
+                onBack={() => router.push(getDashboardPath("areas"))}
+                onGoToMembers={() => router.push(getDashboardPath("members"))}
                 onOpenMember={(memberId) => {
-                  setSelectedMemberId(memberId);
-                  setView("member-profile");
+                  router.push(getDashboardPath("member-profile", memberId));
                 }}
               />
             )}
-            {view === "members" && (
+            {view === "area-detail" &&
+              routeAuthorized &&
+              loadState === "ready" &&
+              !selectedArea && (
+                <RouteStateView
+                  title="Área no encontrada"
+                  description="El área solicitada no existe o ya no está disponible para tu cuenta."
+                  href={getDashboardPath("areas")}
+                  action="Volver a áreas"
+                />
+              )}
+            {view === "members" && routeAuthorized && (
               <MembersManagementView
                 members={members}
                 areas={areas}
@@ -344,12 +376,11 @@ export default function DashboardPage() {
                 currentRole={currentMember.role}
                 onChanged={refreshPeopleData}
                 onOpenMember={(memberId) => {
-                  setSelectedMemberId(memberId);
-                  setView("member-profile");
+                  router.push(getDashboardPath("member-profile", memberId));
                 }}
               />
             )}
-            {view === "member-profile" && selectedMember && (
+            {view === "member-profile" && routeAuthorized && selectedMember && (
               <MemberProfileManagementView
                 member={selectedMember}
                 areas={areas}
@@ -357,10 +388,21 @@ export default function DashboardPage() {
                 accessToken={accessToken}
                 currentRole={currentMember.role}
                 onChanged={refreshPeopleData}
-                onBack={() => setView("members")}
+                onBack={() => router.push(getDashboardPath("members"))}
               />
             )}
-            {view === "projects" && accessToken && (
+            {view === "member-profile" &&
+              routeAuthorized &&
+              loadState === "ready" &&
+              !selectedMember && (
+                <RouteStateView
+                  title="Miembro no encontrado"
+                  description="El perfil solicitado no existe o no está disponible para tu cuenta."
+                  href={getDashboardPath("members")}
+                  action="Volver a miembros"
+                />
+              )}
+            {view === "projects" && routeAuthorized && accessToken && (
               <ProjectManagement
                 projects={projects}
                 areas={areas}
@@ -371,7 +413,7 @@ export default function DashboardPage() {
                 onProjectsChanged={refreshProjects}
               />
             )}
-            {view === "tasks" && accessToken && (
+            {view === "tasks" && routeAuthorized && accessToken && (
               <TaskManagement
                 projects={projects}
                 accessToken={accessToken}
@@ -379,13 +421,13 @@ export default function DashboardPage() {
                 currentMember={currentMember}
               />
             )}
-            {view === "integrations" && (
+            {view === "integrations" && routeAuthorized && (
               <PlaceholderView title="Integraciones" />
             )}
-            {view === "audit" && accessToken && (
+            {view === "audit" && routeAuthorized && accessToken && (
               <AuditManagementView accessToken={accessToken} />
             )}
-            {view === "profile" && (
+            {view === "profile" && routeAuthorized && (
               <ProfileView member={currentMember} onLogout={handleLogout} />
             )}
           </div>

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -17,6 +17,8 @@
     "src/app/project-experience.test.ts",
     "src/app/people-management-utils.ts",
     "src/app/people-management-utils.test.ts",
+    "src/app/dashboard/dashboard-route.ts",
+    "src/app/dashboard/dashboard-route.test.ts",
     "src/app/task-collaboration.ts",
     "src/app/task-collaboration.test.ts",
     "src/app/task-management.tsx",


### PR DESCRIPTION
## What changed

- Added canonical dashboard routes for areas, area detail, members, member profiles, projects, tasks, integrations, audit, and profile.
- Replaced dashboard-only view state with URL-driven navigation.
- Added deep-link handling, browser back/forward support, and clear unauthorized, missing-resource, and invalid-route states.
- Converted sidebar navigation to Next.js links.
- Added focused route parsing, path generation, navigation-state, and authorization tests.

## Why

Dashboard navigation previously depended on local component state, so refreshes and pasted detail URLs could not restore the selected view.

## Impact

Users can now bookmark, refresh, paste, and navigate backward or forward through canonical application URLs without losing area or member context. Direct navigation continues to enforce role visibility.

## Validation

- `npm run type-check --workspace frontend`
- `npm run test --workspace frontend` — 25 passing
- `npm run lint --workspace frontend`
- `npm run build --workspace frontend`
- Browser smoke test: `/dashboard/areas/42` loaded without console errors or a framework error overlay and preserved the unauthenticated redirect to `/login`.

Linear: [UNI2-37](https://linear.app/unicode-dev/issue/UNI2-37/fixfrontend-standardize-application-routes-and-deep-link-navigation)