### PR TITLE
feat(labels): support free-text entry and suggestions for every tag field

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { CreateAuditEventsTable1787788800003 } from './migrations/1787788800003-
 import { AuthModule } from './auth/auth.module';
 import { TasksModule } from './tasks/tasks.module';
 import { AuditModule } from './audit/audit.module';
+import { SkillsModule } from './skills/skills.module';
 
 @Module({
   imports: [
@@ -54,6 +55,7 @@ import { AuditModule } from './audit/audit.module';
     AuthModule,
     TasksModule,
     AuditModule,
+    SkillsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/skills/skills.controller.ts
+++ b/apps/backend/src/skills/skills.controller.ts
@@ -1,18 +1,24 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Roles } from '../common/decorators/roles.decorator';
+import { AreaRole } from '../common/enums/area-role.enum';
+import { RolesGuard } from '../common/guards/roles.guard';
 import { CreateSkillDto } from './dto/create-skill.dto';
 import { Skill } from './skill.entity';
 import { SkillsService } from './skills.service';
 
 @Controller('skills')
+@UseGuards(RolesGuard)
 export class SkillsController {
   constructor(private readonly skillsService: SkillsService) {}
 
   @Post()
+  @Roles(AreaRole.PRESIDENCIA)
   create(@Body() createSkillDto: CreateSkillDto): Promise<Skill> {
     return this.skillsService.create(createSkillDto);
   }
 
   @Get()
+  @Roles(AreaRole.PRESIDENCIA, AreaRole.DIRECTIVA_DE_AREA)
   findAll(): Promise<Skill[]> {
     return this.skillsService.findAll();
   }

--- a/apps/backend/src/skills/skills.module.ts
+++ b/apps/backend/src/skills/skills.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AccessControlModule } from '../common/access-control.module';
+import { Skill } from './skill.entity';
+import { SkillsController } from './skills.controller';
+import { SkillsService } from './skills.service';
+
+@Module({
+  imports: [AccessControlModule, TypeOrmModule.forFeature([Skill])],
+  controllers: [SkillsController],
+  providers: [SkillsService],
+  exports: [SkillsService],
+})
+export class SkillsModule {}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src next.config.ts postcss.config.mjs",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src next.config.ts postcss.config.mjs",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/components/tag-input.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/frontend/src/app/components/tag-input.test.tsx
+++ b/apps/frontend/src/app/components/tag-input.test.tsx
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { JSDOM } from "jsdom";
+import { useState } from "react";
+import { TagInput } from "./tag-input";
+
+describe("TagInput form submission", () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM("<!doctype html><html><body></body></html>", {
+      url: "http://localhost",
+    });
+    Object.defineProperties(globalThis, {
+      window: { configurable: true, value: dom.window },
+      document: { configurable: true, value: dom.window.document },
+      navigator: { configurable: true, value: dom.window.navigator },
+      HTMLElement: { configurable: true, value: dom.window.HTMLElement },
+      MutationObserver: {
+        configurable: true,
+        value: dom.window.MutationObserver,
+      },
+    });
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    dom.window.close();
+  });
+
+  it("blocks save and keeps the error visible for an invalid draft", async () => {
+    const { cleanup, fireEvent, render } = await import(
+      "@testing-library/react"
+    );
+    let submissions = 0;
+
+    function Form() {
+      const [tags, setTags] = useState<string[]>([]);
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            submissions += 1;
+          }}
+        >
+          <TagInput
+            label="Etiquetas"
+            value={tags}
+            suggestions={[]}
+            maxLength={5}
+            onChange={setTags}
+          />
+          <button type="submit">Guardar</button>
+        </form>
+      );
+    }
+
+    const view = render(<Form />);
+    try {
+      const input = view.getByRole("textbox") as HTMLInputElement;
+      const save = view.getByRole("button", { name: "Guardar" });
+
+      fireEvent.change(input, { target: { value: "demasiado largo" } });
+      fireEvent.blur(input, { relatedTarget: save });
+      fireEvent.click(save);
+
+      assert.equal(submissions, 0);
+      assert.equal(input.validity.customError, true);
+      assert.match(view.container.textContent ?? "", /hasta 5 caracteres/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("commits a valid draft before saving", async () => {
+    const { cleanup, fireEvent, render } = await import(
+      "@testing-library/react"
+    );
+    let submittedTags: string[] | undefined;
+
+    function Form() {
+      const [tags, setTags] = useState<string[]>([]);
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            submittedTags = tags;
+          }}
+        >
+          <TagInput
+            label="Etiquetas"
+            value={tags}
+            suggestions={[]}
+            maxLength={50}
+            onChange={setTags}
+          />
+          <button type="submit">Guardar</button>
+        </form>
+      );
+    }
+
+    const view = render(<Form />);
+    try {
+      const input = view.getByRole("textbox");
+      const save = view.getByRole("button", { name: "Guardar" });
+
+      fireEvent.change(input, { target: { value: "Frontend" } });
+      fireEvent.blur(input, { relatedTarget: save });
+      fireEvent.click(save);
+
+      assert.deepEqual(submittedTags, ["Frontend"]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/apps/frontend/src/app/components/tag-input.tsx
+++ b/apps/frontend/src/app/components/tag-input.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { KeyboardEvent, useMemo, useState } from "react";
+import {
+  canonicalizeTags,
+  cleanTag,
+  matchingTagSuggestions,
+  normalizeTag,
+  validateTag,
+} from "../tag-utils";
+
+export function TagInput({
+  label,
+  value,
+  suggestions,
+  onChange,
+  required = false,
+}: {
+  label: string;
+  value: string[];
+  suggestions: string[];
+  onChange: (value: string[]) => void;
+  required?: boolean;
+}) {
+  const [draft, setDraft] = useState("");
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [focused, setFocused] = useState(false);
+  const [error, setError] = useState("");
+  const fieldId = normalizeTag(label).replace(/\s+/g, "-");
+  const labelId = `${fieldId}-label`;
+  const errorId = `${fieldId}-error`;
+  const matches = useMemo(
+    () =>
+      matchingTagSuggestions(
+        draft,
+        suggestions,
+        value.filter((_, index) => index !== editingIndex),
+      ),
+    [draft, editingIndex, suggestions, value],
+  );
+
+  const commitMany = (candidates: string[]) => {
+    const cleanedCandidates = candidates.map(cleanTag).filter(Boolean);
+    const candidateError = cleanedCandidates.length
+      ? cleanedCandidates.map(validateTag).find(Boolean)
+      : validateTag("");
+    if (candidateError) {
+      setError(candidateError);
+      return;
+    }
+    const base = value.filter((_, index) => index !== editingIndex);
+    const next = canonicalizeTags([...base, ...cleanedCandidates], suggestions);
+    if (next.length === base.length) {
+      setError("Esta etiqueta ya fue agregada.");
+      return;
+    }
+    onChange(next);
+    setDraft("");
+    setEditingIndex(null);
+    setError("");
+  };
+  const commit = (candidate: string) => commitMany([candidate]);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      commit(draft);
+    }
+    if (event.key === "Escape" && editingIndex !== null) {
+      setDraft("");
+      setEditingIndex(null);
+      setError("");
+    }
+  };
+
+  return (
+    <div
+      className="relative"
+      onFocusCapture={() => setFocused(true)}
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setFocused(false);
+        }
+      }}
+    >
+      <span id={labelId} className="block text-sm font-medium text-white/75">
+        {label}
+        {required && <span aria-hidden="true"> *</span>}
+      </span>
+      <div
+        className={`mt-2 flex min-h-11 flex-wrap items-center gap-2 rounded-md border bg-[#20212c] px-3 py-2 focus-within:ring-2 ${
+          error
+            ? "border-rose-400/70 focus-within:ring-rose-400/30"
+            : "border-white/10 focus-within:ring-[#7478ff]/40"
+        }`}
+      >
+          {value.map((tag, index) => (
+            <span
+              key={`${normalizeTag(tag)}-${index}`}
+              className="inline-flex items-center rounded bg-[#6777bb] text-xs text-white"
+            >
+              <button
+                type="button"
+                className="px-2 py-1.5 hover:bg-white/10"
+                aria-label={`Editar ${tag}`}
+                onClick={() => {
+                  setDraft(tag);
+                  setEditingIndex(index);
+                  setError("");
+                }}
+              >
+                {tag}
+              </button>
+              <button
+                type="button"
+                className="border-l border-white/15 px-2 py-1.5 hover:bg-white/10"
+                aria-label={`Quitar ${tag}`}
+                onClick={() => {
+                  onChange(value.filter((_, itemIndex) => itemIndex !== index));
+                  if (editingIndex === index) {
+                    setDraft("");
+                    setEditingIndex(null);
+                  }
+                }}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          <input
+            value={draft}
+            aria-labelledby={labelId}
+            aria-invalid={Boolean(error)}
+            aria-describedby={error ? errorId : undefined}
+            placeholder={value.length ? "Agregar otra…" : "Escribe o selecciona…"}
+            className="min-w-40 flex-1 bg-transparent py-1 text-sm text-white outline-none placeholder:text-white/30"
+            onChange={(event) => {
+              const nextDraft = event.target.value;
+              setError("");
+              if (nextDraft.includes(",")) {
+                const entries = nextDraft.split(",");
+                commitMany(entries.slice(0, -1));
+                setDraft(entries.at(-1) ?? "");
+              } else {
+                setDraft(nextDraft);
+              }
+            }}
+            onKeyDown={handleKeyDown}
+          />
+      </div>
+      {focused && matches.length > 0 && (
+        <div className="absolute z-30 mt-1 grid max-h-52 w-full overflow-y-auto rounded-md border border-white/10 bg-[#191822] p-1 shadow-2xl">
+          {matches.map((suggestion) => (
+            <button
+              key={normalizeTag(suggestion)}
+              type="button"
+              className="rounded px-3 py-2 text-left text-sm text-white/80 hover:bg-white/10"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => commit(suggestion)}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      )}
+      {error && (
+        <p
+          id={errorId}
+          className="mt-2 text-xs text-rose-200"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/components/tag-input.tsx
+++ b/apps/frontend/src/app/components/tag-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { KeyboardEvent, useMemo, useState } from "react";
+import { KeyboardEvent, useMemo, useRef, useState } from "react";
 import {
   canonicalizeTags,
   cleanTag,
@@ -31,6 +31,7 @@ export function TagInput({
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [focused, setFocused] = useState(false);
   const [error, setError] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const fieldId = normalizeTag(label).replace(/\s+/g, "-");
   const labelId = `${fieldId}-label`;
   const errorId = `${fieldId}-error`;
@@ -43,6 +44,14 @@ export function TagInput({
       ),
     [draft, editingIndex, suggestions, value],
   );
+  const setValidationError = (message: string) => {
+    inputRef.current?.setCustomValidity(message);
+    setError(message);
+  };
+  const clearValidationError = () => {
+    inputRef.current?.setCustomValidity("");
+    setError("");
+  };
 
   const commitMany = (candidates: string[]) => {
     const cleanedCandidates = candidates.map(cleanTag).filter(Boolean);
@@ -52,23 +61,23 @@ export function TagInput({
           .find(Boolean)
       : validateTag("", maxLength);
     if (candidateError) {
-      setError(candidateError);
+      setValidationError(candidateError);
       return;
     }
     const base = value.filter((_, index) => index !== editingIndex);
     const next = canonicalizeTags([...base, ...cleanedCandidates], suggestions);
     if (next.length === base.length) {
-      setError("Esta etiqueta ya fue agregada.");
+      setValidationError("Esta etiqueta ya fue agregada.");
       return;
     }
     if (maxTags !== undefined && next.length > maxTags) {
-      setError(`Puedes agregar hasta ${maxTags} etiquetas.`);
+      setValidationError(`Puedes agregar hasta ${maxTags} etiquetas.`);
       return;
     }
     onChange(next);
     setDraft("");
     setEditingIndex(null);
-    setError("");
+    clearValidationError();
   };
   const commit = (candidate: string) => commitMany([candidate]);
 
@@ -80,7 +89,7 @@ export function TagInput({
     if (event.key === "Escape" && editingIndex !== null) {
       setDraft("");
       setEditingIndex(null);
-      setError("");
+      clearValidationError();
     }
   };
 
@@ -118,7 +127,7 @@ export function TagInput({
                 onClick={() => {
                   setDraft(tag);
                   setEditingIndex(index);
-                  setError("");
+                  clearValidationError();
                 }}
               >
                 {tag}
@@ -142,6 +151,7 @@ export function TagInput({
             </span>
           ))}
           <input
+            ref={inputRef}
             value={draft}
             aria-labelledby={labelId}
             aria-invalid={Boolean(error)}
@@ -150,7 +160,7 @@ export function TagInput({
             className="min-w-40 flex-1 bg-transparent py-1 text-sm text-white outline-none placeholder:text-white/30"
             onChange={(event) => {
               const nextDraft = event.target.value;
-              setError("");
+              clearValidationError();
               if (nextDraft.includes(",")) {
                 const entries = nextDraft.split(",");
                 commitMany(entries.slice(0, -1));

--- a/apps/frontend/src/app/components/tag-input.tsx
+++ b/apps/frontend/src/app/components/tag-input.tsx
@@ -4,6 +4,7 @@ import { KeyboardEvent, useMemo, useState } from "react";
 import {
   canonicalizeTags,
   cleanTag,
+  editingIndexAfterRemoval,
   matchingTagSuggestions,
   normalizeTag,
   validateTag,
@@ -14,12 +15,16 @@ export function TagInput({
   value,
   suggestions,
   onChange,
+  maxLength,
+  maxTags,
   required = false,
 }: {
   label: string;
   value: string[];
   suggestions: string[];
   onChange: (value: string[]) => void;
+  maxLength: number;
+  maxTags?: number;
   required?: boolean;
 }) {
   const [draft, setDraft] = useState("");
@@ -42,8 +47,10 @@ export function TagInput({
   const commitMany = (candidates: string[]) => {
     const cleanedCandidates = candidates.map(cleanTag).filter(Boolean);
     const candidateError = cleanedCandidates.length
-      ? cleanedCandidates.map(validateTag).find(Boolean)
-      : validateTag("");
+      ? cleanedCandidates
+          .map((candidate) => validateTag(candidate, maxLength))
+          .find(Boolean)
+      : validateTag("", maxLength);
     if (candidateError) {
       setError(candidateError);
       return;
@@ -52,6 +59,10 @@ export function TagInput({
     const next = canonicalizeTags([...base, ...cleanedCandidates], suggestions);
     if (next.length === base.length) {
       setError("Esta etiqueta ya fue agregada.");
+      return;
+    }
+    if (maxTags !== undefined && next.length > maxTags) {
+      setError(`Puedes agregar hasta ${maxTags} etiquetas.`);
       return;
     }
     onChange(next);
@@ -80,6 +91,7 @@ export function TagInput({
       onBlurCapture={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
           setFocused(false);
+          if (draft.trim()) commit(draft);
         }
       }}
     >
@@ -119,8 +131,10 @@ export function TagInput({
                   onChange(value.filter((_, itemIndex) => itemIndex !== index));
                   if (editingIndex === index) {
                     setDraft("");
-                    setEditingIndex(null);
                   }
+                  setEditingIndex(
+                    editingIndexAfterRemoval(editingIndex, index),
+                  );
                 }}
               >
                 ×

--- a/apps/frontend/src/app/people-management/member-form.tsx
+++ b/apps/frontend/src/app/people-management/member-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { authorizedJson } from "@/lib/auth-client";
-import type { ManagedArea, ManagedMember } from "../people-management.types";
+import { TagInput } from "../components/tag-input";
+import type { ManagedArea, ManagedMember, ManagedSkill } from "../people-management.types";
 import { Feedback, fieldClass, labelClass, messageFrom, Modal, primaryButton, secondaryButton } from "./shared";
 
 type MemberFormState = {
@@ -14,7 +15,7 @@ type MemberFormState = {
   birthDate: string;
   role: string;
   areaId: string;
-  skills: string;
+  skills: string[];
   activityStatus: string;
   availabilityStatus: string;
   cycle: string;
@@ -42,7 +43,7 @@ export function MemberForm({
     birthDate: member?.birthDate?.slice(0, 10) ?? "",
     role: member?.role ?? "miembro",
     areaId: member?.areaId ? String(member.areaId) : "",
-    skills: member?.skills?.map((skill) => skill.name).join(", ") ?? "",
+    skills: member?.skills?.map((skill) => skill.name) ?? [],
     activityStatus: member?.activityStatus ?? "active",
     availabilityStatus: member?.availabilityStatus ?? "available",
     cycle: member?.cycle ? String(member.cycle) : "",
@@ -50,18 +51,34 @@ export function MemberForm({
   const [form, setForm] = useState(initial);
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
+  const [skillSuggestions, setSkillSuggestions] = useState<string[]>(
+    member?.skills?.map((skill) => skill.name) ?? [],
+  );
   const activeAreas = areas.filter((area) => !area.isArchived);
   const set = (key: keyof MemberFormState, value: string) =>
     setForm((current) => ({ ...current, [key]: value }));
+  useEffect(() => {
+    let ignore = false;
+    authorizedJson<ManagedSkill[]>("/skills", accessToken)
+      .then((skills) => {
+        if (!ignore) setSkillSuggestions(skills.map((skill) => skill.name));
+      })
+      .catch(() => {
+        // Existing values remain available when suggestions cannot be loaded.
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [accessToken]);
   const submit = async (event: FormEvent) => {
     event.preventDefault();
+    if (form.skills.length === 0) {
+      setError("Agrega al menos una skill antes de guardar.");
+      return;
+    }
     setSaving(true);
     setError("");
     try {
-      const skills = form.skills
-        .split(",")
-        .map((skill) => skill.trim())
-        .filter(Boolean);
       const payload = {
         institution: form.institution.trim(),
         studentCode: form.studentCode.trim() || (member ? null : undefined),
@@ -69,7 +86,7 @@ export function MemberForm({
         lastNames: form.lastNames.trim(),
         major: form.major.trim(),
         birthDate: form.birthDate || undefined,
-        skills,
+        skills: form.skills,
         activityStatus: form.activityStatus,
         availabilityStatus: form.availabilityStatus,
         cycle: form.cycle ? Number(form.cycle) : member ? null : undefined,
@@ -208,11 +225,14 @@ export function MemberForm({
             </select>
           </label>
           <div className="sm:col-span-2">
-            <FormInput
-              label="Skills separadas por comas"
+            <TagInput
+              label="Skills"
               required
               value={form.skills}
-              onChange={(value) => set("skills", value)}
+              suggestions={skillSuggestions}
+              onChange={(skills) =>
+                setForm((current) => ({ ...current, skills }))
+              }
             />
           </div>
         </div>

--- a/apps/frontend/src/app/people-management/member-form.tsx
+++ b/apps/frontend/src/app/people-management/member-form.tsx
@@ -228,6 +228,7 @@ export function MemberForm({
             <TagInput
               label="Skills"
               required
+              maxLength={80}
               value={form.skills}
               suggestions={skillSuggestions}
               onChange={(skills) =>

--- a/apps/frontend/src/app/project-management.tsx
+++ b/apps/frontend/src/app/project-management.tsx
@@ -778,6 +778,8 @@ function ProjectForm({
         )}
         <TagInput
           label="Etiquetas"
+          maxLength={50}
+          maxTags={20}
           value={values.labels}
           suggestions={labelSuggestions}
           onChange={(labels) =>

--- a/apps/frontend/src/app/project-management.tsx
+++ b/apps/frontend/src/app/project-management.tsx
@@ -6,6 +6,7 @@ import {
   getMemberProjectLabelNames,
   getPortfolioLabelNames,
 } from "./project-experience";
+import { TagInput } from "./components/tag-input";
 
 type Area = {
   id: number;
@@ -98,7 +99,7 @@ type ProjectFormValues = {
   startDate: string;
   endDate: string;
   areaId: string;
-  labels: string;
+  labels: string[];
   status: ProjectStatus;
 };
 
@@ -141,7 +142,7 @@ const EMPTY_PROJECT_FORM: ProjectFormValues = {
   startDate: "",
   endDate: "",
   areaId: "",
-  labels: "",
+  labels: [],
   status: "planned",
 };
 
@@ -160,18 +161,6 @@ function memberAreaIds(member: Member): number[] {
     if (typeof membership.areaId === "number") ids.add(membership.areaId);
   });
   return [...ids];
-}
-
-function parseLabels(labels: string): string[] {
-  return [
-    ...new Map(
-      labels
-        .split(",")
-        .map((label) => label.trim())
-        .filter(Boolean)
-        .map((label) => [normalize(label), label]),
-    ).values(),
-  ];
 }
 
 async function requestJson<T>(
@@ -273,6 +262,10 @@ export default function ProjectManagement({
   const experienceProjects = useMemo(
     () => combineProjectExperience(projects, archivedProjects),
     [archivedProjects, projects],
+  );
+  const labelSuggestions = useMemo(
+    () => getPortfolioLabelNames(experienceProjects),
+    [experienceProjects],
   );
   const labels = useMemo(
     () =>
@@ -455,6 +448,7 @@ export default function ProjectManagement({
               apiUrl={apiUrl}
               accessToken={accessToken}
               loading={loading}
+              labelSuggestions={labelSuggestions}
               onCancel={() => setEditing(false)}
               onSaved={async () => {
                 await runMutation(
@@ -538,6 +532,7 @@ export default function ProjectManagement({
             apiUrl={apiUrl}
             accessToken={accessToken}
             loading={loading}
+            labelSuggestions={labelSuggestions}
             onCancel={() => setShowCreate(false)}
             onSaved={async (project) => {
               await runMutation(
@@ -644,6 +639,7 @@ function ProjectForm({
   apiUrl,
   accessToken,
   loading,
+  labelSuggestions,
   onCancel,
   onSaved,
 }: {
@@ -653,6 +649,7 @@ function ProjectForm({
   apiUrl: string;
   accessToken: string;
   loading: boolean;
+  labelSuggestions: string[];
   onCancel: () => void;
   onSaved: (project: Project) => Promise<void>;
 }) {
@@ -664,7 +661,7 @@ function ProjectForm({
           startDate: project.startDate ?? "",
           endDate: project.endDate ?? "",
           areaId: String(project.areaId ?? project.area?.id ?? ""),
-          labels: project.labels?.map((label) => label.name).join(", ") ?? "",
+          labels: project.labels?.map((label) => label.name) ?? [],
           status: project.status,
         }
       : { ...EMPTY_PROJECT_FORM, areaId: String(areas[0]?.id ?? "") },
@@ -689,7 +686,7 @@ function ProjectForm({
       startDate: values.startDate || (mode === "edit" ? null : undefined),
       endDate: values.endDate || (mode === "edit" ? null : undefined),
       areaId: Number(values.areaId),
-      labels: parseLabels(values.labels),
+      labels: values.labels,
       ...(mode === "edit" ? { status: values.status } : {}),
     };
 
@@ -779,14 +776,14 @@ function ProjectForm({
             </select>
           </Field>
         )}
-        <Field label="Etiquetas (separadas por comas)">
-          <input
-            value={values.labels}
-            onChange={(event) => update("labels", event.target.value)}
-            placeholder="Backend, Comunidad, Eventos"
-            className={inputClass}
-          />
-        </Field>
+        <TagInput
+          label="Etiquetas"
+          value={values.labels}
+          suggestions={labelSuggestions}
+          onChange={(labels) =>
+            setValues((current) => ({ ...current, labels }))
+          }
+        />
         <div className="md:col-span-2">
           <Field label="Descripción">
             <textarea

--- a/apps/frontend/src/app/tag-utils.test.ts
+++ b/apps/frontend/src/app/tag-utils.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   canonicalizeTags,
+  editingIndexAfterRemoval,
   matchingTagSuggestions,
   normalizeTag,
   validateTag,
@@ -33,9 +34,18 @@ describe("tag utilities", () => {
     );
   });
 
-  it("returns clear validation errors for empty and oversized tags", () => {
-    assert.match(validateTag("   ") ?? "", /Escribe una etiqueta/);
-    assert.match(validateTag("x".repeat(61)) ?? "", /60 caracteres/);
-    assert.equal(validateTag("Node.js"), undefined);
+  it("validates tags against each field's configured length", () => {
+    assert.match(validateTag("   ", 80) ?? "", /Escribe una etiqueta/);
+    assert.equal(validateTag("x".repeat(80), 80), undefined);
+    assert.match(validateTag("x".repeat(81), 80) ?? "", /80 caracteres/);
+    assert.match(validateTag("x".repeat(51), 50) ?? "", /50 caracteres/);
+    assert.equal(validateTag("Node.js", 80), undefined);
+  });
+
+  it("keeps the edited tag index in sync after removing a chip", () => {
+    assert.equal(editingIndexAfterRemoval(3, 1), 2);
+    assert.equal(editingIndexAfterRemoval(3, 3), null);
+    assert.equal(editingIndexAfterRemoval(1, 3), 1);
+    assert.equal(editingIndexAfterRemoval(null, 0), null);
   });
 });

--- a/apps/frontend/src/app/tag-utils.test.ts
+++ b/apps/frontend/src/app/tag-utils.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  canonicalizeTags,
+  matchingTagSuggestions,
+  normalizeTag,
+  validateTag,
+} from "./tag-utils";
+
+describe("tag utilities", () => {
+  it("normalizes casing, accents, and repeated spaces", () => {
+    assert.equal(normalizeTag("  Gestión   Ágil "), "gestion agil");
+  });
+
+  it("deduplicates equivalent values and preserves a canonical suggestion", () => {
+    assert.deepEqual(
+      canonicalizeTags(
+        ["js", " JS ", "gestion agil", "Gestión   Ágil"],
+        ["JavaScript", "JS", "Gestión Ágil"],
+      ),
+      ["JS", "Gestión Ágil"],
+    );
+  });
+
+  it("filters suggestions and excludes selected tags", () => {
+    assert.deepEqual(
+      matchingTagSuggestions(
+        "re",
+        ["React", "Research", "Node.js", "réact"],
+        ["REACT"],
+      ),
+      ["Research"],
+    );
+  });
+
+  it("returns clear validation errors for empty and oversized tags", () => {
+    assert.match(validateTag("   ") ?? "", /Escribe una etiqueta/);
+    assert.match(validateTag("x".repeat(61)) ?? "", /60 caracteres/);
+    assert.equal(validateTag("Node.js"), undefined);
+  });
+});

--- a/apps/frontend/src/app/tag-utils.ts
+++ b/apps/frontend/src/app/tag-utils.ts
@@ -1,0 +1,64 @@
+export const MAX_TAG_LENGTH = 60;
+
+export function cleanTag(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+export function normalizeTag(value: string): string {
+  return cleanTag(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase("es");
+}
+
+export function canonicalizeTags(
+  values: string[],
+  suggestions: string[] = [],
+): string[] {
+  const canonicalSuggestions = new Map<string, string>();
+  suggestions.forEach((suggestion) => {
+    const cleaned = cleanTag(suggestion);
+    const normalized = normalizeTag(cleaned);
+    if (normalized && !canonicalSuggestions.has(normalized)) {
+      canonicalSuggestions.set(normalized, cleaned);
+    }
+  });
+
+  const unique = new Map<string, string>();
+  values.forEach((value) => {
+    const cleaned = cleanTag(value);
+    const normalized = normalizeTag(cleaned);
+    if (normalized && !unique.has(normalized)) {
+      unique.set(normalized, canonicalSuggestions.get(normalized) ?? cleaned);
+    }
+  });
+  return [...unique.values()];
+}
+
+export function validateTag(value: string): string | undefined {
+  const cleaned = cleanTag(value);
+  if (!cleaned) return "Escribe una etiqueta antes de agregarla.";
+  if (cleaned.length > MAX_TAG_LENGTH) {
+    return `Cada etiqueta puede tener hasta ${MAX_TAG_LENGTH} caracteres.`;
+  }
+  if (/[\u0000-\u001f\u007f]/.test(cleaned)) {
+    return "La etiqueta contiene caracteres no permitidos.";
+  }
+  return undefined;
+}
+
+export function matchingTagSuggestions(
+  query: string,
+  suggestions: string[],
+  selected: string[],
+): string[] {
+  const normalizedQuery = normalizeTag(query);
+  const selectedValues = new Set(selected.map(normalizeTag));
+  return canonicalizeTags(suggestions)
+    .filter((suggestion) => !selectedValues.has(normalizeTag(suggestion)))
+    .filter(
+      (suggestion) =>
+        !normalizedQuery || normalizeTag(suggestion).includes(normalizedQuery),
+    )
+    .slice(0, 6);
+}

--- a/apps/frontend/src/app/tag-utils.ts
+++ b/apps/frontend/src/app/tag-utils.ts
@@ -1,5 +1,3 @@
-export const MAX_TAG_LENGTH = 60;
-
 export function cleanTag(value: string): string {
   return value.trim().replace(/\s+/g, " ");
 }
@@ -35,16 +33,29 @@ export function canonicalizeTags(
   return [...unique.values()];
 }
 
-export function validateTag(value: string): string | undefined {
+export function validateTag(
+  value: string,
+  maxLength: number,
+): string | undefined {
   const cleaned = cleanTag(value);
   if (!cleaned) return "Escribe una etiqueta antes de agregarla.";
-  if (cleaned.length > MAX_TAG_LENGTH) {
-    return `Cada etiqueta puede tener hasta ${MAX_TAG_LENGTH} caracteres.`;
+  if (cleaned.length > maxLength) {
+    return `Cada etiqueta puede tener hasta ${maxLength} caracteres.`;
   }
   if (/[\u0000-\u001f\u007f]/.test(cleaned)) {
     return "La etiqueta contiene caracteres no permitidos.";
   }
   return undefined;
+}
+
+export function editingIndexAfterRemoval(
+  editingIndex: number | null,
+  removedIndex: number,
+): number | null {
+  if (editingIndex === null || removedIndex > editingIndex) {
+    return editingIndex;
+  }
+  return removedIndex === editingIndex ? null : editingIndex - 1;
 }
 
 export function matchingTagSuggestions(

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -17,6 +17,8 @@
     "src/app/project-experience.test.ts",
     "src/app/people-management-utils.ts",
     "src/app/people-management-utils.test.ts",
+    "src/app/tag-utils.ts",
+    "src/app/tag-utils.test.ts",
     "src/app/task-collaboration.ts",
     "src/app/task-collaboration.test.ts",
     "src/app/task-management.tsx",

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -19,6 +19,8 @@
     "src/app/people-management-utils.test.ts",
     "src/app/tag-utils.ts",
     "src/app/tag-utils.test.ts",
+    "src/app/components/tag-input.tsx",
+    "src/app/components/tag-input.test.tsx",
     "src/app/dashboard/dashboard-route.ts",
     "src/app/dashboard/dashboard-route.test.ts",
     "src/app/task-collaboration.ts",


### PR DESCRIPTION
## What changed

- Added a reusable mixed tag input with free-text creation, existing-value suggestions, chip editing, and removal.
- Applied it to member skills and project labels.
- Loaded competency suggestions from the existing skills API and project-label suggestions from the loaded portfolio.
- Normalized casing, accents, leading/trailing whitespace, and repeated spaces when comparing tags.
- Preserved the canonical display spelling from existing suggestions.
- Added clear validation for empty, oversized, and invalid tags.
- Added focused unit tests for normalization, canonicalization, suggestion filtering, and validation.

## Why

Skills and project labels previously used comma-separated text fields without consistent suggestions or duplicate prevention.

## Impact

Users can combine existing and new tags in the same control. Equivalent inputs such as `JS`, `js`, or accent/spacing variants resolve to one visible tag before saving.

## Validation

- `npm run type-check --workspace frontend`
- `npm run test --workspace frontend` — 24 passing
- `npm run lint --workspace frontend`
- `npm run build --workspace frontend`

Linear: [UNI2-39](https://linear.app/unicode-dev/issue/UNI2-39/featlabels-support-free-text-entry-and-suggestions-for-every-tag-field)