### PR TITLE
Uni2 40 testv1 verify project candidate search and eligibility rules

### DIFF
--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -208,6 +208,7 @@ describe('ProjectsService', () => {
   let taskAssigneesRepository: TaskAssigneeRepositoryMock;
   let auditService: jest.Mocked<AuditService>;
   let memberAvailabilityService: jest.Mocked<MemberAvailabilityService>;
+  let memberActivityService: jest.Mocked<MemberActivityService>;
 
   const mockAreaService = {
     findOne: jest.fn(),
@@ -309,6 +310,7 @@ describe('ProjectsService', () => {
           provide: MemberAvailabilityService,
           useValue: {
             refreshProjectMembers: jest.fn().mockResolvedValue(undefined),
+            refreshMembers: jest.fn().mockResolvedValue(undefined),
           },
         },
         {
@@ -363,6 +365,7 @@ describe('ProjectsService', () => {
     service = module.get<ProjectsService>(ProjectsService);
     auditService = module.get(AuditService);
     memberAvailabilityService = module.get(MemberAvailabilityService);
+    memberActivityService = module.get(MemberActivityService);
   });
 
   it('creates a project with default phases when the area exists', async () => {
@@ -1266,6 +1269,14 @@ describe('ProjectsService', () => {
         membership,
       );
       expect(projectsRepository.manager.transaction).toHaveBeenCalledTimes(1);
+      expect(memberActivityService.refreshMembers).toHaveBeenCalledWith(
+        [1],
+        expect.anything(),
+      );
+      expect(memberAvailabilityService.refreshMembers).toHaveBeenCalledWith(
+        [1],
+        expect.anything(),
+      );
       expect(projectsRepository.findOne).toHaveBeenCalledWith({
         where: { id: 1 },
         lock: { mode: 'pessimistic_write' },
@@ -1305,6 +1316,49 @@ describe('ProjectsService', () => {
           'Members marked as unavailable are not selectable when building a team',
         ),
       );
+      expect(projectMembershipsRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('allows inactive members when their derived availability is available', async () => {
+      const member = createMember({
+        activityStatus: MemberActivityStatus.INACTIVE,
+        availabilityStatus: MemberAvailabilityStatus.AVAILABLE,
+      });
+      const membership = createProjectMembership({ member });
+
+      projectsRepository.findOne?.mockResolvedValue(createProject());
+      membersRepository.findOne?.mockResolvedValue(member);
+      projectMembershipsRepository.findOne
+        ?.mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(membership);
+      projectMembershipsRepository.create?.mockReturnValue(membership);
+      projectMembershipsRepository.save?.mockResolvedValue(membership);
+
+      await expect(
+        service.addTeamMember(
+          1,
+          { memberId: 1, role: ProjectRole.MEMBER },
+          presidencyActor,
+        ),
+      ).resolves.toEqual(membership);
+    });
+
+    it.each([
+      MemberAvailabilityStatus.NOT_AVAILABLE,
+      MemberAvailabilityStatus.DISABLED,
+    ])('rejects a member with %s derived availability', async (status) => {
+      projectsRepository.findOne?.mockResolvedValue(createProject());
+      membersRepository.findOne?.mockResolvedValue(
+        createMember({ availabilityStatus: status }),
+      );
+
+      await expect(
+        service.addTeamMember(
+          1,
+          { memberId: 1, role: ProjectRole.MEMBER },
+          presidencyActor,
+        ),
+      ).rejects.toThrow(BadRequestException);
       expect(projectMembershipsRepository.save).not.toHaveBeenCalled();
     });
 

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -1317,6 +1317,15 @@ describe('ProjectsService', () => {
         ),
       );
       expect(projectMembershipsRepository.save).not.toHaveBeenCalled();
+      expect(memberActivityService.refreshMembers).toHaveBeenCalledWith(
+        [1],
+        expect.anything(),
+      );
+      expect(memberAvailabilityService.refreshMembers).toHaveBeenCalledWith(
+        [1],
+        expect.anything(),
+      );
+      expect(projectsRepository.manager.transaction).toHaveBeenCalledTimes(1);
     });
 
     it('allows inactive members when their derived availability is available', async () => {

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -536,7 +536,7 @@ export class ProjectsService {
     addDto: AddProjectMemberDto,
     accessActor: RequestAccessActor,
   ): Promise<ProjectMembership> {
-    return this.projectsRepository.manager.transaction(
+    const membership = await this.projectsRepository.manager.transaction(
       async (entityManager) => {
         const project = await this.findProjectForUpdate(
           projectId,
@@ -568,9 +568,7 @@ export class ProjectsService {
         }
 
         if (member.availabilityStatus !== MemberAvailabilityStatus.AVAILABLE) {
-          throw new BadRequestException(
-            'Members marked as unavailable are not selectable when building a team',
-          );
+          return null;
         }
 
         const belongsToArea = member.memberships?.some(
@@ -637,6 +635,14 @@ export class ProjectsService {
         }
       },
     );
+
+    if (!membership) {
+      throw new BadRequestException(
+        'Members marked as unavailable are not selectable when building a team',
+      );
+    }
+
+    return membership;
   }
 
   async updateTeamMemberRole(

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -546,6 +546,16 @@ export class ProjectsService {
         const membersRepository = entityManager.getRepository(Member);
         const projectMembershipsRepository =
           entityManager.getRepository(ProjectMembership);
+
+        await this.memberActivityService.refreshMembers(
+          [addDto.memberId],
+          entityManager,
+        );
+        await this.memberAvailabilityService.refreshMembers(
+          [addDto.memberId],
+          entityManager,
+        );
+
         const member = await membersRepository.findOne({
           where: { id: addDto.memberId },
           relations: ['memberships'],

--- a/apps/frontend/src/app/project-experience.test.ts
+++ b/apps/frontend/src/app/project-experience.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   combineProjectExperience,
+  filterAndSortProjectCandidates,
   getMemberProjectLabelNames,
   getPortfolioLabelNames,
   normalizeCandidateFilter,
@@ -54,5 +55,77 @@ describe("project experience filters", () => {
       normalizeCandidateFilter("Gestión Ágil"),
       normalizeCandidateFilter("gestion agil"),
     );
+  });
+
+  it("combines every candidate filter and keeps inactive matches last", () => {
+    const projects = [
+      {
+        labels: [{ name: "Gestión Ágil" }],
+        memberships: [{ memberId: 10 }, { memberId: 11 }],
+      },
+    ];
+    const members = [
+      {
+        id: 11,
+        firstNames: "Álvaro",
+        lastNames: "Zapata",
+        major: "Ingeniería de Sistemas",
+        cycle: 8,
+        activityStatus: "inactive",
+        skills: [{ name: "Análisis de datos" }],
+      },
+      {
+        id: 10,
+        firstNames: "Beatriz",
+        lastNames: "Alva",
+        major: "Ingeniería de Sistemas",
+        cycle: 8,
+        activityStatus: "active",
+        skills: [{ name: "Análisis de datos" }],
+      },
+      {
+        id: 12,
+        firstNames: "Carlos",
+        lastNames: "Ramos",
+        major: "Ingeniería Industrial",
+        cycle: 8,
+        activityStatus: "active",
+        skills: [{ name: "Análisis de datos" }],
+      },
+    ];
+
+    const result = filterAndSortProjectCandidates(members, projects, {
+      query: "ingenieria",
+      skill: "analisis de datos",
+      projectLabel: "gestion agil",
+      cycle: "8",
+      major: "ingenieria de sistemas",
+    });
+
+    assert.deepEqual(result.map(({ id }) => id), [10, 11]);
+  });
+
+  it("returns no candidates when one combined filter does not match", () => {
+    const members = [
+      {
+        id: 10,
+        firstNames: "Beatriz",
+        lastNames: "Alva",
+        major: "Ingeniería de Sistemas",
+        cycle: 8,
+        activityStatus: "active",
+        skills: [{ name: "Backend" }],
+      },
+    ];
+
+    const result = filterAndSortProjectCandidates(members, [], {
+      query: "beatriz",
+      skill: "frontend",
+      projectLabel: "",
+      cycle: "8",
+      major: "ingenieria de sistemas",
+    });
+
+    assert.deepEqual(result, []);
   });
 });

--- a/apps/frontend/src/app/project-experience.test.ts
+++ b/apps/frontend/src/app/project-experience.test.ts
@@ -4,6 +4,7 @@ import {
   combineProjectExperience,
   getMemberProjectLabelNames,
   getPortfolioLabelNames,
+  normalizeCandidateFilter,
 } from "./project-experience";
 
 describe("project experience filters", () => {
@@ -42,5 +43,16 @@ describe("project experience filters", () => {
     combineProjectExperience(activeProjects, archivedProjects);
 
     assert.deepEqual(activeProjects.map((project) => project.id), [1]);
+  });
+
+  it("normalizes accents, casing, and repeated whitespace in candidate filters", () => {
+    assert.equal(
+      normalizeCandidateFilter("  Ingeniería   de Sistemas "),
+      normalizeCandidateFilter("ingenieria de sistemas"),
+    );
+    assert.equal(
+      normalizeCandidateFilter("Gestión Ágil"),
+      normalizeCandidateFilter("gestion agil"),
+    );
   });
 });

--- a/apps/frontend/src/app/project-experience.ts
+++ b/apps/frontend/src/app/project-experience.ts
@@ -3,6 +3,24 @@ export type ProjectExperienceSource = {
   memberships?: Array<{ memberId: number }>;
 };
 
+export type CandidateFilterMember = {
+  id: number;
+  firstNames: string;
+  lastNames: string;
+  major: string;
+  cycle?: number | null;
+  activityStatus?: string;
+  skills?: Array<{ name: string }>;
+};
+
+export type CandidateFilters = {
+  query: string;
+  skill: string;
+  projectLabel: string;
+  cycle: string;
+  major: string;
+};
+
 export function combineProjectExperience<T>(
   activeProjects: T[],
   archivedProjects: T[],
@@ -17,6 +35,46 @@ export function normalizeCandidateFilter(value: string): string {
     .trim()
     .replace(/\s+/g, " ")
     .toLocaleLowerCase();
+}
+
+export function filterAndSortProjectCandidates<T extends CandidateFilterMember>(
+  members: T[],
+  projects: ProjectExperienceSource[],
+  filters: CandidateFilters,
+): T[] {
+  const normalizedQuery = normalizeCandidateFilter(filters.query);
+  const normalizedSkill = normalizeCandidateFilter(filters.skill);
+  const normalizedLabel = normalizeCandidateFilter(filters.projectLabel);
+  const normalizedMajor = normalizeCandidateFilter(filters.major);
+
+  return members
+    .filter((member) => {
+      const searchableProfile = normalizeCandidateFilter(
+        `${member.firstNames} ${member.lastNames} ${member.major}`,
+      );
+      const skills =
+        member.skills?.map(({ name }) => normalizeCandidateFilter(name)) ?? [];
+      const labels = getMemberProjectLabelNames(projects, member.id).map(
+        normalizeCandidateFilter,
+      );
+
+      return (
+        (!normalizedQuery || searchableProfile.includes(normalizedQuery)) &&
+        (!normalizedSkill || skills.includes(normalizedSkill)) &&
+        (!normalizedLabel || labels.includes(normalizedLabel)) &&
+        (!filters.cycle || member.cycle === Number(filters.cycle)) &&
+        (!normalizedMajor ||
+          normalizeCandidateFilter(member.major) === normalizedMajor)
+      );
+    })
+    .sort((left, right) => {
+      const activityOrder =
+        Number(left.activityStatus === "inactive") -
+        Number(right.activityStatus === "inactive");
+      const leftName = `${left.firstNames} ${left.lastNames}`.trim();
+      const rightName = `${right.firstNames} ${right.lastNames}`.trim();
+      return activityOrder || leftName.localeCompare(rightName);
+    });
 }
 
 export function getPortfolioLabelNames(

--- a/apps/frontend/src/app/project-experience.ts
+++ b/apps/frontend/src/app/project-experience.ts
@@ -10,6 +10,15 @@ export function combineProjectExperience<T>(
   return [...activeProjects, ...archivedProjects];
 }
 
+export function normalizeCandidateFilter(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLocaleLowerCase();
+}
+
 export function getPortfolioLabelNames(
   projects: ProjectExperienceSource[],
 ): string[] {

--- a/apps/frontend/src/app/project-management.tsx
+++ b/apps/frontend/src/app/project-management.tsx
@@ -9,9 +9,8 @@ import {
 } from "react";
 import {
   combineProjectExperience,
-  getMemberProjectLabelNames,
+  filterAndSortProjectCandidates,
   getPortfolioLabelNames,
-  normalizeCandidateFilter,
 } from "./project-experience";
 import {
   DropPlacement,
@@ -1023,45 +1022,17 @@ function TeamPanel({
   ).sort((a, b) => a.localeCompare(b));
   const projectLabels = getPortfolioLabelNames(portfolioProjects);
 
-  const candidates = areaCandidates
-    .filter((member) => {
-      const memberSkills =
-        member.skills?.map((skill) => normalizeCandidateFilter(skill.name)) ?? [];
-      const matchesQuery =
-        !normalizeCandidateFilter(candidateQuery) ||
-        normalizeCandidateFilter(`${memberName(member)} ${member.major}`).includes(
-          normalizeCandidateFilter(candidateQuery),
-        );
-      const matchesSkill =
-        !skillFilter ||
-        memberSkills.includes(normalizeCandidateFilter(skillFilter));
-      const memberProjectLabels = getMemberProjectLabelNames(
-        portfolioProjects,
-        member.id,
-      ).map(normalizeCandidateFilter);
-      const matchesProjectLabel =
-        !labelFilter ||
-        memberProjectLabels.includes(normalizeCandidateFilter(labelFilter));
-      const matchesCycle =
-        !cycleFilter || member.cycle === Number(cycleFilter);
-      const matchesMajor =
-        !majorFilter ||
-        normalizeCandidateFilter(member.major) ===
-          normalizeCandidateFilter(majorFilter);
-      return (
-        matchesQuery &&
-        matchesSkill &&
-        matchesProjectLabel &&
-        matchesCycle &&
-        matchesMajor
-      );
-    })
-    .sort((a, b) => {
-      const activityOrder =
-        Number(a.activityStatus === "inactive") -
-        Number(b.activityStatus === "inactive");
-      return activityOrder || memberName(a).localeCompare(memberName(b));
-    });
+  const candidates = filterAndSortProjectCandidates(
+    areaCandidates,
+    portfolioProjects,
+    {
+      query: candidateQuery,
+      skill: skillFilter,
+      projectLabel: labelFilter,
+      cycle: cycleFilter,
+      major: majorFilter,
+    },
+  );
 
   const mutate = async (
     path: string,

--- a/apps/frontend/src/app/project-management.tsx
+++ b/apps/frontend/src/app/project-management.tsx
@@ -11,6 +11,7 @@ import {
   combineProjectExperience,
   getMemberProjectLabelNames,
   getPortfolioLabelNames,
+  normalizeCandidateFilter,
 } from "./project-experience";
 import {
   DropPlacement,
@@ -1024,24 +1025,29 @@ function TeamPanel({
 
   const candidates = areaCandidates
     .filter((member) => {
-      const memberSkills = member.skills?.map((skill) => normalize(skill.name)) ?? [];
+      const memberSkills =
+        member.skills?.map((skill) => normalizeCandidateFilter(skill.name)) ?? [];
       const matchesQuery =
-        !normalize(candidateQuery) ||
-        normalize(`${memberName(member)} ${member.major}`).includes(
-          normalize(candidateQuery),
+        !normalizeCandidateFilter(candidateQuery) ||
+        normalizeCandidateFilter(`${memberName(member)} ${member.major}`).includes(
+          normalizeCandidateFilter(candidateQuery),
         );
       const matchesSkill =
-        !skillFilter || memberSkills.includes(normalize(skillFilter));
+        !skillFilter ||
+        memberSkills.includes(normalizeCandidateFilter(skillFilter));
       const memberProjectLabels = getMemberProjectLabelNames(
         portfolioProjects,
         member.id,
-      ).map(normalize);
+      ).map(normalizeCandidateFilter);
       const matchesProjectLabel =
         !labelFilter ||
-        memberProjectLabels.includes(normalize(labelFilter));
+        memberProjectLabels.includes(normalizeCandidateFilter(labelFilter));
       const matchesCycle =
         !cycleFilter || member.cycle === Number(cycleFilter);
-      const matchesMajor = !majorFilter || member.major === majorFilter;
+      const matchesMajor =
+        !majorFilter ||
+        normalizeCandidateFilter(member.major) ===
+          normalizeCandidateFilter(majorFilter);
       return (
         matchesQuery &&
         matchesSkill &&


### PR DESCRIPTION
## Summary

Completes UNI2-40 by validating and strengthening the project candidate search and eligibility flow across the frontend and backend.

Candidate filters now handle accented and unaccented values consistently, can be combined, and keep inactive candidates after active candidates. The backend recalculates derived activity and availability before adding a member, preventing stale eligibility data from bypassing assignment rules.

## Related Issue / Requirement

- Issue: UNI2-40
- GitHub Issue: test(v1): verify project candidate search and eligibility rules #61
- Requirements:
  - Filter candidates by competencies, previous project labels, cycle, and career.
  - Allow all required filters to be combined.
  - Treat accented and unaccented filter values equivalently.
  - Limit candidates to available members from the project area.
  - Show inactive candidates after active candidates.
  - Recalculate activity and availability from active-project task assignments before validating eligibility.
  - Reject ineligible candidates through the API even when the UI is bypassed.

## What Changed

- Added / Updated:
  - Added accent-, case-, and whitespace-insensitive candidate filter normalization.
  - Extracted candidate filtering and sorting into a shared, testable frontend utility.
  - Added tests for combined filters, accent normalization, nonmatching filters, and active-before-inactive ordering.
  - Expanded backend tests for available, inactive, unavailable, and disabled candidates.
- Backend / Frontend support for:
  - Backend recalculation of candidate activity and availability inside the assignment transaction.
  - Backend enforcement of current derived availability before project assignment.
  - Frontend filtering by name, career, competency, previous project label, and cycle.
  - Frontend ranking of active candidates before inactive candidates.

## How to Test

From the repository root:

- Run `npm run type-check -w frontend`
- Run `npm run lint -w frontend`
- Run `npm run test -w frontend`
- Run `npm run build -w frontend`
- Run `npm run type-check -w backend`
- Run `npm run lint -w backend`
- Run `npm run test -w backend`
- Run `npm run build -w backend`

Focused backend tests:

- Run `npm test -- --runInBand projects.service.spec.ts` from `apps/backend`

Manual checks:

- Log in as Presidencia or Directiva de Área.
- Open a project and select the option to add a team member.
- Verify that only available, unassigned members from the project area are shown.
- Combine competency, previous project label, cycle, career, and text filters.
- Verify that accented and unaccented searches return equivalent results.
- Verify that active candidates appear before inactive candidates.
- Attempt to add an unavailable or disabled member directly through the API and verify that the request is rejected.
- Change a member’s active-project task assignments and verify that eligibility is recalculated before assignment.

## Screenshots / Evidence

Local verification:

- Frontend type-check: OK.
- Frontend lint: OK.
- Frontend tests: 42/42 passed.
- Frontend build: Not run.
- Backend type-check: OK.
- Backend lint for changed files: OK.
- Backend build: Not run.
- Focused backend tests: 47/47 passed.
- Full backend lint: Blocked by pre-existing errors in the uncommitted local `apps/backend/src/seed.ts` file, which is not part of this PR.

<!-- Attach screenshots, UI captures, or terminal logs here -->