### PR TITLE
feat(members): add members directly from an area context

### DIFF
--- a/apps/frontend/src/app/dashboard/dashboard-route.test.ts
+++ b/apps/frontend/src/app/dashboard/dashboard-route.test.ts
@@ -3,7 +3,9 @@ import { describe, it } from "node:test";
 import {
   canAccessDashboardRoute,
   getDashboardPath,
+  getMemberCreationPath,
   getRouteNavView,
+  parseMemberCreationAreaId,
   parseDashboardPath,
 } from "./dashboard-route";
 
@@ -17,6 +19,9 @@ describe("dashboard canonical routes", () => {
     assert.deepEqual(parseDashboardPath("/dashboard/members/7/"), {
       view: "member-profile",
       resourceId: 7,
+    });
+    assert.deepEqual(parseDashboardPath("/dashboard/members/new"), {
+      view: "member-create",
     });
   });
 
@@ -40,6 +45,18 @@ describe("dashboard canonical routes", () => {
       getDashboardPath("member-profile", 15),
       "/dashboard/members/15",
     );
+    assert.equal(getMemberCreationPath(), "/dashboard/members/new");
+    assert.equal(
+      getMemberCreationPath(12),
+      "/dashboard/members/new?areaId=12",
+    );
+  });
+
+  it("parses a valid area context without accepting invalid identifiers", () => {
+    assert.equal(parseMemberCreationAreaId("12"), 12);
+    assert.equal(parseMemberCreationAreaId(null), undefined);
+    assert.equal(parseMemberCreationAreaId("0"), undefined);
+    assert.equal(parseMemberCreationAreaId("other"), undefined);
   });
 
   it("keeps detail routes active under their parent navigation item", () => {
@@ -51,6 +68,7 @@ describe("dashboard canonical routes", () => {
       getRouteNavView({ view: "member-profile", resourceId: 9 }),
       "members",
     );
+    assert.equal(getRouteNavView({ view: "member-create" }), "members");
   });
 
   it("preserves people and audit authorization on direct navigation", () => {

--- a/apps/frontend/src/app/dashboard/dashboard-route.ts
+++ b/apps/frontend/src/app/dashboard/dashboard-route.ts
@@ -5,7 +5,10 @@ export type DashboardRoute = {
   resourceId?: number;
 };
 
-const VIEW_PATHS: Record<Exclude<View, "area-detail" | "member-profile">, string> = {
+const VIEW_PATHS: Record<
+  Exclude<View, "area-detail" | "member-create" | "member-profile">,
+  string
+> = {
   dashboard: "/dashboard",
   areas: "/dashboard/areas",
   members: "/dashboard/members",
@@ -23,7 +26,8 @@ function parsePositiveId(value: string): number | undefined {
 }
 
 export function parseDashboardPath(pathname: string): DashboardRoute {
-  const normalizedPath = pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+  const normalizedPath =
+    pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
 
   const staticRoute = Object.entries(VIEW_PATHS).find(
     ([, path]) => path === normalizedPath,
@@ -36,6 +40,10 @@ export function parseDashboardPath(pathname: string): DashboardRoute {
     return resourceId
       ? { view: "area-detail", resourceId }
       : { view: "not-found" };
+  }
+
+  if (normalizedPath === "/dashboard/members/new") {
+    return { view: "member-create" };
   }
 
   const memberMatch = normalizedPath.match(/^\/dashboard\/members\/([^/]+)$/);
@@ -51,19 +59,34 @@ export function parseDashboardPath(pathname: string): DashboardRoute {
 
 export function getDashboardPath(view: View, resourceId?: number): string {
   if (view === "area-detail") {
-    if (!resourceId) throw new Error("El detalle de área requiere un identificador");
+    if (!resourceId)
+      throw new Error("El detalle de área requiere un identificador");
     return `/dashboard/areas/${resourceId}`;
   }
   if (view === "member-profile") {
     if (!resourceId) throw new Error("El perfil de miembro requiere un identificador");
     return `/dashboard/members/${resourceId}`;
   }
+  if (view === "member-create") return "/dashboard/members/new";
   return VIEW_PATHS[view];
+}
+
+export function getMemberCreationPath(areaId?: number): string {
+  const path = getDashboardPath("member-create");
+  return areaId ? `${path}?areaId=${areaId}` : path;
+}
+
+export function parseMemberCreationAreaId(
+  value: string | null,
+): number | undefined {
+  return value === null ? undefined : parsePositiveId(value);
 }
 
 export function getRouteNavView(route: DashboardRoute): View | undefined {
   if (route.view === "area-detail") return "areas";
-  if (route.view === "member-profile") return "members";
+  if (route.view === "member-create" || route.view === "member-profile") {
+    return "members";
+  }
   return route.view === "not-found" ? undefined : route.view;
 }
 

--- a/apps/frontend/src/app/dashboard/dashboard.types.ts
+++ b/apps/frontend/src/app/dashboard/dashboard.types.ts
@@ -3,6 +3,7 @@ export type View =
   | "areas"
   | "area-detail"
   | "members"
+  | "member-create"
   | "member-profile"
   | "projects"
   | "tasks"

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import {
   ApiError,
   API_URL,
@@ -18,6 +18,8 @@ import {
   MemberProfileManagementView,
   MembersManagementView,
 } from "../people-management";
+import { canCreateMemberInArea } from "../people-management-utils";
+import { MemberForm } from "../people-management/member-form";
 import type {
   Area,
   AuthState,
@@ -37,7 +39,9 @@ import {
 import {
   canAccessDashboardRoute,
   getDashboardPath,
+  getMemberCreationPath,
   getRouteNavView,
+  parseMemberCreationAreaId,
   parseDashboardPath,
 } from "./dashboard-route";
 import {
@@ -51,7 +55,16 @@ import {
 } from "./dashboard.components";
 
 export default function DashboardPage() {
+  return (
+    <Suspense fallback={<SessionLoadingView />}>
+      <DashboardContent />
+    </Suspense>
+  );
+}
+
+function DashboardContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const params = useParams<{ segments?: string[] }>();
   const pathname = params.segments?.length
     ? `/dashboard/${params.segments.join("/")}`
@@ -238,6 +251,28 @@ export default function DashboardPage() {
       ? members.find((member) => member.id === route.resourceId)
       : undefined;
 
+  const hasCreationAreaContext =
+    view === "member-create" && searchParams.has("areaId");
+  const creationAreaId =
+    view === "member-create"
+      ? parseMemberCreationAreaId(searchParams.get("areaId"))
+      : undefined;
+  const creationArea = creationAreaId
+    ? areas.find((area) => area.id === creationAreaId && !area.isArchived)
+    : undefined;
+  const canCreateMember =
+    view === "member-create" &&
+    !currentMember?.readOnly &&
+    (hasCreationAreaContext
+      ? Boolean(creationArea) &&
+        creationAreaId !== undefined &&
+        canCreateMemberInArea(
+          currentMemberRole ?? "",
+          currentMember?.areaId,
+          creationAreaId,
+        )
+      : currentMemberRole === "presidencia");
+
   const activeMembers = members.filter(
     (member) => member.activityStatus !== "inactive",
   ).length;
@@ -363,6 +398,9 @@ export default function DashboardPage() {
                 currentAreaId={currentMember.areaId}
                 onChanged={refreshPeopleData}
                 onBack={() => router.push(getDashboardPath("areas"))}
+                onAddMember={(areaId) => {
+                  router.push(getMemberCreationPath(areaId));
+                }}
                 onOpenMember={(memberId) => {
                   router.push(getDashboardPath("member-profile", memberId));
                 }}
@@ -384,14 +422,61 @@ export default function DashboardPage() {
                 members={members}
                 areas={areas}
                 projects={projects}
-                accessToken={accessToken}
                 currentRole={currentMember.role}
-                onChanged={refreshPeopleData}
+                onCreateMember={() => router.push(getMemberCreationPath())}
                 onOpenMember={(memberId) => {
                   router.push(getDashboardPath("member-profile", memberId));
                 }}
               />
             )}
+            {view === "member-create" &&
+              routeAuthorized &&
+              loadState === "ready" &&
+              canCreateMember && (
+                <MemberForm
+                  areas={areas}
+                  accessToken={accessToken}
+                  initialAreaId={creationAreaId}
+                  fixedAreaId={
+                    currentMember.role === "directiva_de_area"
+                      ? creationAreaId
+                      : undefined
+                  }
+                  regularMemberOnly={
+                    currentMember.role === "directiva_de_area"
+                  }
+                  onClose={() => {
+                    router.replace(
+                      creationAreaId
+                        ? getDashboardPath("area-detail", creationAreaId)
+                        : getDashboardPath("members"),
+                    );
+                  }}
+                  onSaved={async (memberId) => {
+                    await refreshPeopleData();
+                    router.replace(
+                      creationAreaId
+                        ? getDashboardPath("area-detail", creationAreaId)
+                        : getDashboardPath("member-profile", memberId),
+                    );
+                  }}
+                />
+              )}
+            {view === "member-create" &&
+              routeAuthorized &&
+              loadState === "ready" &&
+              !canCreateMember && (
+                <RouteStateView
+                  title="No se puede añadir el miembro"
+                  description="El área solicitada no está activa o tu rol no permite crear miembros en ella."
+                  href={
+                    creationAreaId
+                      ? getDashboardPath("area-detail", creationAreaId)
+                      : getDashboardPath("members")
+                  }
+                  action="Volver"
+                />
+              )}
             {view === "member-profile" && routeAuthorized && selectedMember && (
               <MemberProfileManagementView
                 member={selectedMember}

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -260,6 +260,9 @@ function DashboardContent() {
   const creationArea = creationAreaId
     ? areas.find((area) => area.id === creationAreaId && !area.isArchived)
     : undefined;
+  const memberCreationReturnPath = creationAreaId
+    ? getDashboardPath("area-detail", creationAreaId)
+    : getDashboardPath("members");
   const canCreateMember =
     view === "member-create" &&
     !currentMember?.readOnly &&
@@ -446,11 +449,10 @@ function DashboardContent() {
                     currentMember.role === "directiva_de_area"
                   }
                   onClose={() => {
-                    router.replace(
-                      creationAreaId
-                        ? getDashboardPath("area-detail", creationAreaId)
-                        : getDashboardPath("members"),
-                    );
+                    router.replace(memberCreationReturnPath);
+                  }}
+                  onCloseAfterSaveFailure={() => {
+                    window.location.replace(memberCreationReturnPath);
                   }}
                   onSaved={async (memberId) => {
                     await refreshPeopleData();

--- a/apps/frontend/src/app/people-management/areas.tsx
+++ b/apps/frontend/src/app/people-management/areas.tsx
@@ -14,8 +14,6 @@ import {
   SearchField,
 } from "./shared";
 import { MemberTable } from "./members";
-import { MemberForm } from "./member-form";
-
 import { AreaForm, ExactNameAction } from "./area-actions";
 export { ExactNameAction } from "./area-actions";
 
@@ -236,6 +234,7 @@ export function AreaDetailManagementView({
   currentRole,
   currentAreaId,
   onBack,
+  onAddMember,
   onOpenMember,
   onChanged,
 }: {
@@ -244,12 +243,12 @@ export function AreaDetailManagementView({
   currentRole: string;
   currentAreaId?: number | null;
   onBack: () => void;
+  onAddMember: (areaId: number) => void;
   onOpenMember: (memberId: number) => void;
   onChanged: () => Promise<void>;
 }) {
   const [editing, setEditing] = useState(false);
   const [archiving, setArchiving] = useState(false);
-  const [creatingMember, setCreatingMember] = useState(false);
   const canEdit = currentRole === "presidencia";
   const canAddMember = canCreateMemberInArea(
     currentRole,
@@ -310,7 +309,7 @@ export function AreaDetailManagementView({
             <button
               type="button"
               className={primaryButton}
-              onClick={() => setCreatingMember(true)}
+              onClick={() => onAddMember(metric.area.id)}
             >
               ＋ Añadir miembro
             </button>
@@ -345,19 +344,6 @@ export function AreaDetailManagementView({
           onDone={async () => {
             setArchiving(false);
             onBack();
-            await onChanged();
-          }}
-        />
-      )}
-      {creatingMember && (
-        <MemberForm
-          areas={[metric.area]}
-          accessToken={accessToken}
-          fixedAreaId={metric.area.id}
-          regularMemberOnly={currentRole === "directiva_de_area"}
-          onClose={() => setCreatingMember(false)}
-          onSaved={async () => {
-            setCreatingMember(false);
             await onChanged();
           }}
         />

--- a/apps/frontend/src/app/people-management/member-form.tsx
+++ b/apps/frontend/src/app/people-management/member-form.tsx
@@ -40,6 +40,7 @@ export function MemberForm({
   fixedAreaId,
   regularMemberOnly = false,
   onClose,
+  onCloseAfterSaveFailure,
   onSaved,
 }: {
   member?: ManagedMember;
@@ -49,6 +50,7 @@ export function MemberForm({
   fixedAreaId?: number;
   regularMemberOnly?: boolean;
   onClose: () => void;
+  onCloseAfterSaveFailure?: () => void;
   onSaved: (memberId: number) => Promise<void>;
 }) {
   const initial: MemberFormState = {
@@ -74,6 +76,7 @@ export function MemberForm({
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
   const [created, setCreated] = useState(false);
+  const [refreshFailed, setRefreshFailed] = useState(false);
   const submissionStarted = useRef(false);
   const [skillSuggestions, setSkillSuggestions] = useState<string[]>(
     member?.skills?.map((skill) => skill.name) ?? [],
@@ -132,6 +135,7 @@ export function MemberForm({
       try {
         await onSaved(saved.id);
       } catch {
+        setRefreshFailed(true);
         setError(
           member
             ? "El miembro se actualizó correctamente, pero no se pudo actualizar la vista. Cierra el formulario para volver a cargarla."
@@ -145,10 +149,14 @@ export function MemberForm({
       setSaving(false);
     }
   };
+  const close =
+    refreshFailed && onCloseAfterSaveFailure
+      ? onCloseAfterSaveFailure
+      : onClose;
   return (
     <Modal
       title={member ? "Editar miembro" : "Añadir miembro"}
-      onClose={onClose}
+      onClose={close}
     >
       <form onSubmit={submit} className="grid gap-5">
         {error && <Feedback>{error}</Feedback>}
@@ -265,7 +273,7 @@ export function MemberForm({
           </div>
         </div>
         <div className="flex justify-end gap-3">
-          <button type="button" className={secondaryButton} onClick={onClose}>
+          <button type="button" className={secondaryButton} onClick={close}>
             Cancelar
           </button>
           <button disabled={saving || created} className={primaryButton}>

--- a/apps/frontend/src/app/people-management/member-form.tsx
+++ b/apps/frontend/src/app/people-management/member-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useEffect, useRef, useState } from "react";
 import { authorizedJson } from "@/lib/auth-client";
 import { TagInput } from "../components/tag-input";
 import type {
@@ -36,6 +36,7 @@ export function MemberForm({
   member,
   areas,
   accessToken,
+  initialAreaId,
   fixedAreaId,
   regularMemberOnly = false,
   onClose,
@@ -44,6 +45,7 @@ export function MemberForm({
   member?: ManagedMember;
   areas: ManagedArea[];
   accessToken: string;
+  initialAreaId?: number;
   fixedAreaId?: number;
   regularMemberOnly?: boolean;
   onClose: () => void;
@@ -57,17 +59,22 @@ export function MemberForm({
     major: member?.major ?? "",
     birthDate: member?.birthDate?.slice(0, 10) ?? "",
     role: regularMemberOnly ? "miembro" : (member?.role ?? "miembro"),
-    areaId: fixedAreaId
-      ? String(fixedAreaId)
-      : member?.areaId
-        ? String(member.areaId)
-        : "",
+    areaId:
+      fixedAreaId !== undefined
+        ? String(fixedAreaId)
+        : initialAreaId !== undefined
+          ? String(initialAreaId)
+          : member?.areaId
+            ? String(member.areaId)
+            : "",
     skills: member?.skills?.map((skill) => skill.name) ?? [],
     cycle: member?.cycle ? String(member.cycle) : "",
   };
   const [form, setForm] = useState(initial);
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
+  const [created, setCreated] = useState(false);
+  const submissionStarted = useRef(false);
   const [skillSuggestions, setSkillSuggestions] = useState<string[]>(
     member?.skills?.map((skill) => skill.name) ?? [],
   );
@@ -89,10 +96,12 @@ export function MemberForm({
   }, [accessToken]);
   const submit = async (event: FormEvent) => {
     event.preventDefault();
+    if (submissionStarted.current) return;
     if (form.skills.length === 0) {
       setError("Agrega al menos una skill antes de guardar.");
       return;
     }
+    submissionStarted.current = true;
     setSaving(true);
     setError("");
     try {
@@ -119,8 +128,18 @@ export function MemberForm({
         accessToken,
         { method: member ? "PATCH" : "POST", body: JSON.stringify(payload) },
       );
-      await onSaved(saved.id);
+      setCreated(true);
+      try {
+        await onSaved(saved.id);
+      } catch {
+        setError(
+          member
+            ? "El miembro se actualizó correctamente, pero no se pudo actualizar la vista. Cierra el formulario para volver a cargarla."
+            : "El miembro se creó correctamente, pero no se pudo actualizar la vista. Cierra el formulario para volver a cargarla.",
+        );
+      }
     } catch (currentError) {
+      submissionStarted.current = false;
       setError(messageFrom(currentError));
     } finally {
       setSaving(false);
@@ -193,7 +212,9 @@ export function MemberForm({
                 <select
                   required={form.role === "directiva_de_area"}
                   value={form.areaId}
-                  disabled={form.role === "presidencia" || Boolean(fixedAreaId)}
+                  disabled={
+                    form.role === "presidencia" || fixedAreaId !== undefined
+                  }
                   onChange={(event) => set("areaId", event.target.value)}
                   className={fieldClass}
                 >
@@ -247,8 +268,14 @@ export function MemberForm({
           <button type="button" className={secondaryButton} onClick={onClose}>
             Cancelar
           </button>
-          <button disabled={saving} className={primaryButton}>
-            {saving ? "Guardando..." : "Guardar miembro"}
+          <button disabled={saving || created} className={primaryButton}>
+            {created
+              ? member
+                ? "Miembro actualizado"
+                : "Miembro creado"
+              : saving
+                ? "Guardando..."
+                : "Guardar miembro"}
           </button>
         </div>
       </form>

--- a/apps/frontend/src/app/people-management/members.tsx
+++ b/apps/frontend/src/app/people-management/members.tsx
@@ -16,28 +16,22 @@ const emptyFilters: MemberDirectoryFilters = {
   projectLabel: "",
 };
 
-import { MemberForm } from "./member-form";
-export { MemberForm } from "./member-form";
-
 export function MembersManagementView({
   members,
   areas,
   projects,
-  accessToken,
   currentRole,
+  onCreateMember,
   onOpenMember,
-  onChanged,
 }: {
   members: ManagedMember[];
   areas: ManagedArea[];
   projects: ManagedProject[];
-  accessToken: string;
   currentRole: string;
+  onCreateMember: () => void;
   onOpenMember: (memberId: number) => void;
-  onChanged: () => Promise<void>;
 }) {
   const [filters, setFilters] = useState(emptyFilters);
-  const [creating, setCreating] = useState(false);
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const filtered = useMemo(
     () => filterAndSortMembers(members, projects, filters),
@@ -139,23 +133,11 @@ export function MembersManagementView({
           <button
             type="button"
             className="rounded-md bg-[#212330] px-4 py-2.5 text-sm text-white/80 hover:bg-[#2b2d3d]"
-            onClick={() => setCreating(true)}
+            onClick={onCreateMember}
           >
             ＋ &nbsp; Añadir miembro
           </button>
         </div>
-      )}
-      {creating && (
-        <MemberForm
-          areas={areas}
-          accessToken={accessToken}
-          onClose={() => setCreating(false)}
-          onSaved={async (memberId) => {
-            setCreating(false);
-            await onChanged();
-            onOpenMember(memberId);
-          }}
-        />
       )}
     </div>
   );

--- a/apps/frontend/src/app/people-management/profile.tsx
+++ b/apps/frontend/src/app/people-management/profile.tsx
@@ -6,7 +6,7 @@ import { authorizedJson } from "@/lib/auth-client";
 import type { ManagedArea, ManagedAreaMembership, ManagedMember, ManagedProject } from "../people-management.types";
 import { dangerButton, memberName, displayCycle, messageFrom, displayRole, StatusPill, Feedback } from "./shared";
 import { ExactNameAction } from "./areas";
-import { MemberForm } from "./members";
+import { MemberForm } from "./member-form";
 
 import { MembershipForm } from "./membership-form";
 


### PR DESCRIPTION
## Summary

- routes member creation through the canonical `/dashboard/members/new` flow
- preserves the originating area in the URL and preselects it in the form
- restricts Área Directiva users to their own active area
- refreshes people data and returns to the originating area after creation
- prevents duplicate submissions when the post-create refresh fails

## Why

The area detail action previously opened local modal state, so the area context was not represented by a deep link and could be lost during navigation.

## Validation

- `npm run type-check --workspace=frontend`
- `npm run lint --workspace=frontend`
- `npm test --workspace=frontend` — 37 tests passed
- `npm test --workspace=backend -- --runInBand members/members.service.spec.ts members/members.controller.spec.ts` — 42 tests passed
- `npm run build --workspace=frontend`

Closes #57