### PR TITLE
Uni2 38 improvementsearch normalize accent insensitive filters

### DIFF
--- a/apps/backend/src/common/utils/text-normalization.util.spec.ts
+++ b/apps/backend/src/common/utils/text-normalization.util.spec.ts
@@ -1,0 +1,16 @@
+import { cleanText, normalizeText } from './text-normalization.util';
+
+describe('text normalization', () => {
+  it('normalizes accents, casing, repeated whitespace and Unicode forms', () => {
+    expect(normalizeText('  INGENIERI\u0301A   de  Sistemas ')).toBe(
+      'ingenieria de sistemas',
+    );
+    expect(normalizeText('Ingeniería')).toBe(normalizeText('ingenieria'));
+  });
+
+  it('keeps the cleaned display value separate from comparisons', () => {
+    expect(cleanText('  Ingeniería   de Sistemas ')).toBe(
+      'Ingeniería de Sistemas',
+    );
+  });
+});

--- a/apps/backend/src/common/utils/text-normalization.util.ts
+++ b/apps/backend/src/common/utils/text-normalization.util.ts
@@ -1,0 +1,14 @@
+export function cleanText(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+export function normalizeText(value: string): string {
+  return cleanText(value)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('es');
+}
+
+export function normalizedSql(column: string): string {
+  return `unaccent(lower(regexp_replace(trim(${column}), '\\s+', ' ', 'g')))`;
+}

--- a/apps/backend/src/members/dto/get-members-filter.dto.ts
+++ b/apps/backend/src/members/dto/get-members-filter.dto.ts
@@ -10,6 +10,10 @@ import {
 } from 'class-validator';
 import { MemberActivityStatus } from '../enums/member-activity-status.enum';
 import { MemberAvailabilityStatus } from '../enums/member-availability-status.enum';
+import {
+  cleanText,
+  normalizeText,
+} from '../../common/utils/text-normalization.util';
 
 const normalizeEnumValue = <T extends string>(
   value: unknown,
@@ -51,13 +55,27 @@ const normalizeSkills = (value: unknown): unknown => {
   }
 
   return items.map((item) =>
-    typeof item === 'string'
-      ? item.trim().replace(/\s+/g, ' ').toLowerCase()
-      : item,
+    typeof item === 'string' ? normalizeText(item) : item,
   );
 };
 
 export class GetMembersFilterDto {
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? normalizeText(value) : value,
+  )
+  @IsString()
+  @Length(1, 120)
+  search?: string;
+
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? cleanText(value) : value,
+  )
+  @IsString()
+  @Length(1, 120)
+  career?: string;
+
   @IsOptional()
   @Transform(({ value }: { value: unknown }) =>
     normalizeEnumValue(value, Object.values(MemberActivityStatus)),

--- a/apps/backend/src/members/members.service.spec.ts
+++ b/apps/backend/src/members/members.service.spec.ts
@@ -247,7 +247,7 @@ describe('MembersService', () => {
     });
     expect(skillsRepository.find).toHaveBeenCalledWith({
       where: {
-        name: In(['typescript', 'testing']),
+        normalizedName: In(['typescript', 'testing']),
       },
     });
     expect(membersRepository.create).toHaveBeenCalledWith({
@@ -598,7 +598,7 @@ describe('MembersService', () => {
         }),
       );
       expect(skillsRepository.find).toHaveBeenCalledWith({
-        where: { name: In(['nestjs']) },
+        where: { normalizedName: In(['nestjs']) },
       });
     });
 

--- a/apps/backend/src/members/members.service.spec.ts
+++ b/apps/backend/src/members/members.service.spec.ts
@@ -45,6 +45,7 @@ const createSkill = (
   updatedAt: new Date(),
   members: [],
   ...overrides,
+  normalizedName: overrides.normalizedName ?? name,
 });
 
 const createQueryBuilderMock = (members: Member[]) => ({

--- a/apps/backend/src/members/members.service.ts
+++ b/apps/backend/src/members/members.service.ts
@@ -19,6 +19,11 @@ import { AreaRole } from '../common/enums/area-role.enum';
 import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { isUniqueViolation } from '../common/utils/database-errors.util';
 import { parseAreaId } from '../common/utils/parse-area-id.util';
+import {
+  cleanText,
+  normalizedSql,
+  normalizeText,
+} from '../common/utils/text-normalization.util';
 import { Skill } from '../skills/skill.entity';
 import { CreateMemberDto } from './dto/create-member.dto';
 import { GetMembersFilterDto } from './dto/get-members-filter.dto';
@@ -389,6 +394,8 @@ export class MembersService {
     const areaId = filterDto?.areaId;
     const cycle = filterDto?.cycle;
     const skills = filterDto?.skills;
+    const search = filterDto?.search;
+    const career = filterDto?.career;
 
     const query = this.membersRepository
       .createQueryBuilder('member')
@@ -427,6 +434,19 @@ export class MembersService {
       query.andWhere('member.cycle = :cycle', { cycle });
     }
 
+    if (career) {
+      query.andWhere(`${normalizedSql('member.major')} = :career`, {
+        career: normalizeText(career),
+      });
+    }
+
+    if (search) {
+      query.andWhere(
+        `concat_ws(' ', ${normalizedSql('member.firstNames')}, ${normalizedSql('member.lastNames')}, ${normalizedSql('member.major')}, ${normalizedSql('area.name')}, ${normalizedSql('skill.name')}) LIKE :search`,
+        { search: `%${normalizeText(search)}%` },
+      );
+    }
+
     if (skills && skills.length > 0) {
       query
         .andWhere((qb) => {
@@ -435,11 +455,11 @@ export class MembersService {
             .select('member_sub.id')
             .from(Member, 'member_sub')
             .innerJoin('member_sub.skills', 'skill_sub')
-            .where('skill_sub.name IN (:...skills)')
+            .where(`${normalizedSql('skill_sub.name')} IN (:...skills)`)
             .getQuery();
           return `member.id IN ${subQuery}`;
         })
-        .setParameter('skills', skills);
+        .setParameter('skills', skills.map(normalizeText));
     }
 
     return query.getMany();
@@ -485,21 +505,36 @@ export class MembersService {
     skillNames: string[],
     skillsRepository: Repository<Skill> = this.skillsRepository,
   ): Promise<Skill[]> {
-    const uniqueSkillNames = [...new Set(skillNames)];
+    const skillNamesByNormalizedName = new Map<string, string>();
+    skillNames.forEach((name) => {
+      const cleanedName = cleanText(name);
+      const normalizedName = normalizeText(cleanedName);
+      if (normalizedName && !skillNamesByNormalizedName.has(normalizedName)) {
+        skillNamesByNormalizedName.set(normalizedName, cleanedName);
+      }
+    });
+    const normalizedNames = [...skillNamesByNormalizedName.keys()];
 
     const existingSkills = await skillsRepository.find({
       where: {
-        name: In(uniqueSkillNames),
+        normalizedName: In(normalizedNames),
       },
     });
 
     const existingSkillNames = new Set(
-      existingSkills.map((skill) => skill.name),
+      existingSkills.map((skill) =>
+        skill.normalizedName ? skill.normalizedName : normalizeText(skill.name),
+      ),
     );
 
-    const newSkills = uniqueSkillNames
+    const newSkills = normalizedNames
       .filter((name) => !existingSkillNames.has(name))
-      .map((name) => skillsRepository.create({ name }));
+      .map((normalizedName) =>
+        skillsRepository.create({
+          name: skillNamesByNormalizedName.get(normalizedName),
+          normalizedName,
+        }),
+      );
 
     const savedNewSkills =
       newSkills.length > 0 ? await skillsRepository.save(newSkills) : [];

--- a/apps/backend/src/migrations/1787788800007-NormalizeSearchableText.ts
+++ b/apps/backend/src/migrations/1787788800007-NormalizeSearchableText.ts
@@ -1,0 +1,104 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NormalizeSearchableText1787788800007 implements MigrationInterface {
+  name = 'NormalizeSearchableText1787788800007';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS unaccent');
+    await queryRunner.query(
+      'ALTER TABLE skills ADD COLUMN normalized_name varchar(120)',
+    );
+    await queryRunner.query(`
+      UPDATE skills
+      SET normalized_name = unaccent(lower(regexp_replace(trim(name), '\\s+', ' ', 'g')))
+    `);
+    await queryRunner.query(`
+      DELETE FROM members_skills_skills duplicate
+      USING members_skills_skills canonical, skills duplicate_skill, skills canonical_skill
+      WHERE duplicate."skillsId" = duplicate_skill.id
+        AND canonical."skillsId" = canonical_skill.id
+        AND duplicate."membersId" = canonical."membersId"
+        AND duplicate_skill.normalized_name = canonical_skill.normalized_name
+        AND duplicate_skill.id > canonical_skill.id
+    `);
+    await queryRunner.query(`
+      UPDATE members_skills_skills membership
+      SET "skillsId" = canonical.id
+      FROM skills duplicate, skills canonical
+      WHERE membership."skillsId" = duplicate.id
+        AND duplicate.normalized_name = canonical.normalized_name
+        AND duplicate.id > canonical.id
+    `);
+    await queryRunner.query(`
+      DELETE FROM skills duplicate
+      USING skills canonical
+      WHERE duplicate.normalized_name = canonical.normalized_name
+        AND duplicate.id > canonical.id
+    `);
+    await queryRunner.query(
+      'ALTER TABLE skills ALTER COLUMN normalized_name SET NOT NULL',
+    );
+    await queryRunner.query(
+      'ALTER TABLE skills DROP CONSTRAINT IF EXISTS "UQ_4c13b20c5a17db0e524e20a837d"',
+    );
+    await queryRunner.query(
+      'CREATE UNIQUE INDEX "IDX_skills_normalized_name" ON skills (normalized_name)',
+    );
+    await queryRunner.query(`
+      DO $$
+      DECLARE constraint_name text;
+      BEGIN
+        SELECT conname INTO constraint_name
+        FROM pg_constraint
+        WHERE conrelid = 'project_labels'::regclass AND contype = 'u';
+        IF constraint_name IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE project_labels DROP CONSTRAINT %I', constraint_name);
+        END IF;
+      END $$
+    `);
+    await queryRunner.query(`
+      UPDATE project_labels
+      SET normalized_name = unaccent(lower(regexp_replace(trim(name), '\\s+', ' ', 'g')))
+    `);
+    await queryRunner.query(`
+      DELETE FROM project_label_assignments duplicate
+      USING project_label_assignments canonical,
+            project_labels duplicate_label,
+            project_labels canonical_label
+      WHERE duplicate.label_id = duplicate_label.id
+        AND canonical.label_id = canonical_label.id
+        AND duplicate.project_id = canonical.project_id
+        AND duplicate_label.normalized_name = canonical_label.normalized_name
+        AND duplicate_label.id > canonical_label.id
+    `);
+    await queryRunner.query(`
+      UPDATE project_label_assignments assignment
+      SET label_id = canonical.id
+      FROM project_labels duplicate, project_labels canonical
+      WHERE assignment.label_id = duplicate.id
+        AND duplicate.normalized_name = canonical.normalized_name
+        AND duplicate.id > canonical.id
+    `);
+    await queryRunner.query(`
+      DELETE FROM project_labels duplicate
+      USING project_labels canonical
+      WHERE duplicate.normalized_name = canonical.normalized_name
+        AND duplicate.id > canonical.id
+    `);
+    await queryRunner.query(
+      'CREATE UNIQUE INDEX "IDX_project_labels_normalized_name" ON project_labels (normalized_name)',
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX "IDX_project_labels_normalized_name"');
+    await queryRunner.query(
+      'ALTER TABLE project_labels ADD CONSTRAINT "UQ_project_labels_normalized_name" UNIQUE (normalized_name)',
+    );
+    await queryRunner.query('DROP INDEX "IDX_skills_normalized_name"');
+    await queryRunner.query('ALTER TABLE skills DROP COLUMN normalized_name');
+    await queryRunner.query(
+      'ALTER TABLE skills ADD CONSTRAINT "UQ_skills_name" UNIQUE (name)',
+    );
+  }
+}

--- a/apps/backend/src/projects/projects.service.spec.ts
+++ b/apps/backend/src/projects/projects.service.spec.ts
@@ -8,8 +8,8 @@ import {
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import {
-  ILike,
   In,
+  FindOperator,
   LessThanOrEqual,
   MoreThanOrEqual,
   ObjectLiteral,
@@ -670,7 +670,10 @@ describe('ProjectsService', () => {
         isArchived: true,
         status: ProjectStatus.ACTIVE,
         areaId: 4,
-        name: ILike('%portal%'),
+        name: expect.objectContaining({
+          _type: 'raw',
+          _objectLiteralParameters: { projectSearch: '%portal%' },
+        }) as FindOperator<string>,
         startDate: LessThanOrEqual('2026-06-30'),
         endDate: MoreThanOrEqual('2026-06-01'),
         labels: { normalizedName: In(['backend']) },

--- a/apps/backend/src/projects/projects.service.ts
+++ b/apps/backend/src/projects/projects.service.ts
@@ -8,10 +8,10 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   FindOptionsWhere,
-  ILike,
   In,
   LessThanOrEqual,
   MoreThanOrEqual,
+  Raw,
   Repository,
 } from 'typeorm';
 import { AreaService } from '../area/area.service';
@@ -20,6 +20,11 @@ import { PaginatedResponse } from '../common/interfaces/paginated-response.inter
 import { RequestAccessActor } from '../common/interfaces/request-access-actor.interface';
 import { isUniqueViolation } from '../common/utils/database-errors.util';
 import { parseAreaId } from '../common/utils/parse-area-id.util';
+import {
+  cleanText,
+  normalizedSql,
+  normalizeText,
+} from '../common/utils/text-normalization.util';
 import { MemberAvailabilityStatus } from '../members/enums/member-availability-status.enum';
 import { MemberActivityStatus } from '../members/enums/member-activity-status.enum';
 import { Member } from '../members/member.entity';
@@ -762,7 +767,10 @@ export class ProjectsService {
       where.areaId = filterDto.areaId;
     }
     if (filterDto.search) {
-      where.name = ILike(`%${filterDto.search}%`);
+      where.name = Raw(
+        (column) => `${normalizedSql(column)} LIKE :projectSearch`,
+        { projectSearch: `%${normalizeText(filterDto.search)}%` },
+      );
     }
     if (filterDto.dateFrom) {
       where.endDate = MoreThanOrEqual(filterDto.dateFrom);
@@ -799,8 +807,8 @@ export class ProjectsService {
     const labelsByNormalizedName = new Map<string, string>();
 
     labelNames.forEach((name) => {
-      const trimmedName = name.trim();
-      labelsByNormalizedName.set(this.normalizeLabel(trimmedName), trimmedName);
+      const trimmedName = cleanText(name);
+      labelsByNormalizedName.set(normalizeText(trimmedName), trimmedName);
     });
 
     const normalizedNames = [...labelsByNormalizedName.keys()];
@@ -860,7 +868,7 @@ export class ProjectsService {
   }
 
   private normalizeLabel(label: string): string {
-    return label.trim().toLocaleLowerCase();
+    return normalizeText(label);
   }
 
   private createDefaultPhases(

--- a/apps/backend/src/skills/dto/create-skill.dto.ts
+++ b/apps/backend/src/skills/dto/create-skill.dto.ts
@@ -1,11 +1,12 @@
 import { Transform, type TransformFnParams } from 'class-transformer';
 import { IsString, Length } from 'class-validator';
+import { cleanText } from '../../common/utils/text-normalization.util';
 
 const normalizeSkill = ({ value }: TransformFnParams): unknown => {
   if (typeof value !== 'string') {
     return value;
   }
-  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+  return cleanText(value);
 };
 
 export class CreateSkillDto {

--- a/apps/backend/src/skills/skill.entity.ts
+++ b/apps/backend/src/skills/skill.entity.ts
@@ -10,13 +10,16 @@ import {
 import { Member } from '../members/member.entity';
 
 @Entity({ name: 'skills' })
-@Unique(['name'])
+@Unique(['normalizedName'])
 export class Skill {
   @PrimaryGeneratedColumn()
   id: number;
 
   @Column({ type: 'varchar', length: 120 })
   name: string;
+
+  @Column({ name: 'normalized_name', type: 'varchar', length: 120 })
+  normalizedName: string;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/apps/backend/src/skills/skills.service.spec.ts
+++ b/apps/backend/src/skills/skills.service.spec.ts
@@ -19,6 +19,7 @@ describe('SkillsService', () => {
   const skillEntity: Skill = {
     id: 1,
     name: 'react',
+    normalizedName: 'react',
     createdAt: new Date('2026-03-30T10:00:00.000Z'),
     updatedAt: new Date('2026-03-30T10:00:00.000Z'),
     members: [],
@@ -105,6 +106,7 @@ describe('SkillsService', () => {
         {
           id: 2,
           name: 'typescript',
+          normalizedName: 'typescript',
           createdAt: new Date('2026-03-30T11:00:00.000Z'),
           updatedAt: new Date('2026-03-30T11:00:00.000Z'),
           members: [],

--- a/apps/backend/src/skills/skills.service.spec.ts
+++ b/apps/backend/src/skills/skills.service.spec.ts
@@ -56,9 +56,29 @@ describe('SkillsService', () => {
 
       const result = await service.create(createSkillDto);
 
-      expect(repository.create).toHaveBeenCalledWith(createSkillDto);
+      expect(repository.create).toHaveBeenCalledWith({
+        name: 'react',
+        normalizedName: 'react',
+      });
       expect(repository.save).toHaveBeenCalledWith(skillEntity);
       expect(result).toEqual(skillEntity);
+    });
+
+    it('preserves the cleaned display name and stores its normalized value', async () => {
+      const accentedSkill = {
+        ...skillEntity,
+        name: 'Gestión de Datos',
+        normalizedName: 'gestion de datos',
+      };
+      repository.create!.mockReturnValue(accentedSkill);
+      repository.save!.mockResolvedValue(accentedSkill);
+
+      await service.create({ name: '  Gestión   de Datos  ' });
+
+      expect(repository.create).toHaveBeenCalledWith({
+        name: 'Gestión de Datos',
+        normalizedName: 'gestion de datos',
+      });
     });
 
     it('throws ConflictException when the skill name already exists', async () => {

--- a/apps/backend/src/skills/skills.service.ts
+++ b/apps/backend/src/skills/skills.service.ts
@@ -4,6 +4,10 @@ import { Repository } from 'typeorm';
 import { CreateSkillDto } from './dto/create-skill.dto';
 import { Skill } from './skill.entity';
 import { isUniqueViolation } from '../common/utils/database-errors.util';
+import {
+  cleanText,
+  normalizeText,
+} from '../common/utils/text-normalization.util';
 
 @Injectable()
 export class SkillsService {
@@ -13,14 +17,18 @@ export class SkillsService {
   ) {}
 
   async create(createSkillDto: CreateSkillDto): Promise<Skill> {
-    const skill = this.skillsRepository.create(createSkillDto);
+    const name = cleanText(createSkillDto.name);
+    const skill = this.skillsRepository.create({
+      name,
+      normalizedName: normalizeText(name),
+    });
 
     try {
       return await this.skillsRepository.save(skill);
     } catch (error) {
       if (isUniqueViolation(error)) {
         throw new ConflictException(
-          `A skill with name "${createSkillDto.name}" already exists.`,
+          `A skill with name "${name}" already exists.`,
         );
       }
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,8 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src next.config.ts postcss.config.mjs",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/components/brand-logo.test.js .test-dist/app/components/tag-input.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/dashboard/dashboard-navigation.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/components/brand-logo.test.js .test-dist/app/components/tag-input.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/phase-reordering.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/components/brand-logo.test.js .test-dist/app/components/tag-input.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/dashboard/dashboard-navigation.test.js .test-dist/app/phase-reordering.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/text-normalization.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/frontend/src/app/people-management-utils.test.ts
+++ b/apps/frontend/src/app/people-management-utils.test.ts
@@ -103,6 +103,31 @@ test("combines directory filters", () => {
   );
 });
 
+test("matches member text, careers, skills and labels without accents", () => {
+  const accentedMember = {
+    ...members[0],
+    firstNames: "Ángela",
+    major: "Ingeniería de Sistemas",
+    skills: [{ name: "Gestión" }],
+  };
+  const accentedProjects = [
+    {
+      labels: [{ name: "Innovación" }],
+      memberships: [{ memberId: accentedMember.id }],
+    },
+  ];
+
+  assert.deepEqual(
+    filterAndSortMembers([accentedMember], accentedProjects, {
+      ...noFilters,
+      query: "gestion",
+      career: "INGENIERIA   DE SISTEMAS",
+      projectLabel: "innovacion",
+    }).map(({ id }) => id),
+    [accentedMember.id],
+  );
+});
+
 test("collects unique project labels for a member", () => {
   assert.deepEqual(getProjectLabelsForMember(2, projects), ["Datos", "Web"]);
 });

--- a/apps/frontend/src/app/people-management-utils.ts
+++ b/apps/frontend/src/app/people-management-utils.ts
@@ -1,3 +1,5 @@
+import { normalizeText, uniqueDisplayValues } from "./text-normalization";
+
 export type MemberDirectoryItem = {
   id: number;
   firstNames: string;
@@ -25,10 +27,6 @@ export type ProjectDirectoryItem = {
   memberships?: Array<{ memberId: number }>;
 };
 
-function normalize(value: string): string {
-  return value.trim().toLocaleLowerCase("es");
-}
-
 export function canCreateMemberInArea(
   role: string,
   actorAreaId: number | null | undefined,
@@ -47,17 +45,15 @@ export function getProjectLabelsForMember(
   memberId: number,
   projects: ProjectDirectoryItem[],
 ): string[] {
-  return [
-    ...new Set(
-      projects
+  return uniqueDisplayValues(
+    projects
         .filter((project) =>
           project.memberships?.some(
             (membership) => membership.memberId === memberId,
           ),
         )
-        .flatMap((project) => project.labels?.map((label) => label.name) ?? []),
-    ),
-  ];
+      .flatMap((project) => project.labels?.map((label) => label.name) ?? []),
+  );
 }
 
 export function filterAndSortMembers<T extends MemberDirectoryItem>(
@@ -65,9 +61,9 @@ export function filterAndSortMembers<T extends MemberDirectoryItem>(
   projects: ProjectDirectoryItem[],
   filters: MemberDirectoryFilters,
 ): T[] {
-  const query = normalize(filters.query);
-  const career = normalize(filters.career);
-  const projectLabel = normalize(filters.projectLabel);
+  const query = normalizeText(filters.query);
+  const career = normalizeText(filters.career);
+  const projectLabel = normalizeText(filters.projectLabel);
 
   return members
     .filter((member) => {
@@ -76,16 +72,16 @@ export function filterAndSortMembers<T extends MemberDirectoryItem>(
           ?.map((membership) => membership.areaId)
           .filter((areaId): areaId is number => typeof areaId === "number") ??
         [];
-      const searchable = [
-        member.firstNames,
-        member.lastNames,
-        member.major,
-        ...(member.skills?.map((skill) => skill.name) ?? []),
-      ]
-        .join(" ")
-        .toLocaleLowerCase("es");
+      const searchable = normalizeText(
+        [
+          member.firstNames,
+          member.lastNames,
+          member.major,
+          ...(member.skills?.map((skill) => skill.name) ?? []),
+        ].join(" "),
+      );
       const labels = getProjectLabelsForMember(member.id, projects).map(
-        normalize,
+        normalizeText,
       );
 
       return (
@@ -95,7 +91,7 @@ export function filterAndSortMembers<T extends MemberDirectoryItem>(
           member.availabilityStatus === filters.availability) &&
         (!filters.areaId || memberAreaIds.includes(Number(filters.areaId))) &&
         (!filters.cycle || member.cycle === Number(filters.cycle)) &&
-        (!career || normalize(member.major) === career) &&
+        (!career || normalizeText(member.major) === career) &&
         (!projectLabel || labels.includes(projectLabel))
       );
     })

--- a/apps/frontend/src/app/people-management/areas.tsx
+++ b/apps/frontend/src/app/people-management/areas.tsx
@@ -15,6 +15,7 @@ import {
 } from "./shared";
 import { MemberTable } from "./members";
 import { AreaForm, ExactNameAction } from "./area-actions";
+import { normalizeText } from "../text-normalization";
 export { ExactNameAction } from "./area-actions";
 
 export function AreasManagementView({
@@ -37,9 +38,9 @@ export function AreasManagementView({
   const [openMenuAreaId, setOpenMenuAreaId] = useState<number | null>(null);
   const canEdit = currentRole === "presidencia";
   const filtered = metrics.filter(({ area }) => {
-    const matchesQuery = `${area.name} ${area.description ?? ""}`
-      .toLocaleLowerCase("es")
-      .includes(query.trim().toLocaleLowerCase("es"));
+    const matchesQuery = normalizeText(
+      `${area.name} ${area.description ?? ""}`,
+    ).includes(normalizeText(query));
     const archived = Boolean(area.isArchived);
     return (
       matchesQuery &&

--- a/apps/frontend/src/app/people-management/members.tsx
+++ b/apps/frontend/src/app/people-management/members.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { filterAndSortMembers, type MemberDirectoryFilters } from "../people-management-utils";
 import type { ManagedArea, ManagedMember, ManagedProject } from "../people-management.types";
 import { fieldClass, memberName, displayCycle, StatusPill, PageHeading, SearchField } from "./shared";
+import { uniqueDisplayValues } from "../text-normalization";
 
 const emptyFilters: MemberDirectoryFilters = {
   query: "",
@@ -44,16 +45,14 @@ export function MembersManagementView({
         .filter((cycle): cycle is number => typeof cycle === "number"),
     ),
   ].sort((a, b) => a - b);
-  const careers = [...new Set(members.map((member) => member.major))].sort(
+  const careers = uniqueDisplayValues(members.map((member) => member.major)).sort(
     (a, b) => a.localeCompare(b, "es"),
   );
-  const labels = [
-    ...new Set(
-      projects.flatMap(
-        (project) => project.labels?.map((label) => label.name) ?? [],
-      ),
+  const labels = uniqueDisplayValues(
+    projects.flatMap(
+      (project) => project.labels?.map((label) => label.name) ?? [],
     ),
-  ].sort((a, b) => a.localeCompare(b, "es"));
+  ).sort((a, b) => a.localeCompare(b, "es"));
   const setFilter = (key: keyof MemberDirectoryFilters, value: string) =>
     setFilters((current) => ({ ...current, [key]: value }));
   return (

--- a/apps/frontend/src/app/project-experience.ts
+++ b/apps/frontend/src/app/project-experience.ts
@@ -29,12 +29,7 @@ export function combineProjectExperience<T>(
 }
 
 export function normalizeCandidateFilter(value: string): string {
-  return value
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .trim()
-    .replace(/\s+/g, " ")
-    .toLocaleLowerCase();
+  return normalizeText(value);
 }
 
 export function filterAndSortProjectCandidates<T extends CandidateFilterMember>(
@@ -80,11 +75,9 @@ export function filterAndSortProjectCandidates<T extends CandidateFilterMember>(
 export function getPortfolioLabelNames(
   projects: ProjectExperienceSource[],
 ): string[] {
-  return Array.from(
-    new Set(
-      projects.flatMap(
-        (project) => project.labels?.map((label) => label.name) ?? [],
-      ),
+  return uniqueDisplayValues(
+    projects.flatMap(
+      (project) => project.labels?.map((label) => label.name) ?? [],
     ),
   ).sort((a, b) => a.localeCompare(b));
 }
@@ -103,3 +96,4 @@ export function getMemberProjectLabelNames(
       (project) => project.labels?.map((label) => label.name) ?? [],
     );
 }
+import { normalizeText, uniqueDisplayValues } from "./text-normalization";

--- a/apps/frontend/src/app/tag-utils.ts
+++ b/apps/frontend/src/app/tag-utils.ts
@@ -1,12 +1,9 @@
-export function cleanTag(value: string): string {
-  return value.trim().replace(/\s+/g, " ");
-}
+import { cleanText, normalizeText } from "./text-normalization";
+
+export const cleanTag = cleanText;
 
 export function normalizeTag(value: string): string {
-  return cleanTag(value)
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLocaleLowerCase("es");
+  return normalizeText(value);
 }
 
 export function canonicalizeTags(

--- a/apps/frontend/src/app/text-normalization.test.ts
+++ b/apps/frontend/src/app/text-normalization.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { cleanText, normalizeText, uniqueDisplayValues } from "./text-normalization";
+
+test("normalizes equivalent accented, cased and spaced text", () => {
+  assert.equal(normalizeText("  INGENIERI\u0301A   "), "ingenieria");
+  assert.equal(normalizeText("Ingeniería"), normalizeText("ingenieria"));
+  assert.equal(cleanText("  Ingeniería   de Sistemas "), "Ingeniería de Sistemas");
+});
+
+test("keeps the first display value when normalized values repeat", () => {
+  assert.deepEqual(
+    uniqueDisplayValues(["Ingeniería", " ingenieria ", "INGENIERÍA"]),
+    ["Ingeniería"],
+  );
+});

--- a/apps/frontend/src/app/text-normalization.ts
+++ b/apps/frontend/src/app/text-normalization.ts
@@ -1,0 +1,20 @@
+export function cleanText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+export function normalizeText(value: string): string {
+  return cleanText(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase("es");
+}
+
+export function uniqueDisplayValues(values: string[]): string[] {
+  const unique = new Map<string, string>();
+  values.forEach((value) => {
+    const cleaned = cleanText(value);
+    const normalized = normalizeText(cleaned);
+    if (normalized && !unique.has(normalized)) unique.set(normalized, cleaned);
+  });
+  return [...unique.values()];
+}


### PR DESCRIPTION
## Summary

Normalizes member and project search/filter behavior so equivalent values match regardless of accents, casing, Unicode form, or repeated whitespace.

The original display values remain unchanged while normalized values are used for comparisons and uniqueness.

## Related Issue / Requirement

- Issue: UNI2-38
- GitHub Issue: improvement(search): normalize accent-insensitive filters across member and project flows #59
- Requirements:
  - Make accented and unaccented values match the same records.
  - Apply consistent normalization across backend and frontend filters.
  - Prevent equivalent project labels and skills from being stored or suggested as duplicates.
  - Preserve original values for display.
  - Cover normalization behavior with automated tests.

## What Changed

- Added / Updated:
  - Added a shared normalization contract that removes diacritics, compares case-insensitively, trims values, and collapses repeated whitespace.
  - Added a migration that enables PostgreSQL `unaccent`, normalizes existing project labels and skills, consolidates duplicates, and enforces normalized skill uniqueness.
  - Added automated coverage for accented, unaccented, cased, spaced, and Unicode-equivalent values.
- Backend / Frontend support for:
  - Accent-insensitive member searches across names, careers, areas, and skills.
  - Accent-insensitive project name and label filtering before pagination.
  - Normalized project label and skill persistence without changing display values.
  - Consistent filtering and suggestion deduplication for members, areas, careers, skills, project labels, and candidate searches.

## How to Test

From the repository root:

- Run `npm run type-check -w frontend`
- Run `npm run lint -w frontend`
- Run `npm run test -w frontend`
- Run `npm run build -w frontend`
- Run `npm run type-check -w backend`
- Run `npm run lint -w backend`
- Run `npm run test -w backend`
- Run `npm run build -w backend`

Focused backend tests:

- Run `npm test -- --runInBand src/common/utils/text-normalization.util.spec.ts src/members/members.service.spec.ts src/projects/projects.service.spec.ts` from `apps/backend`

Manual checks:

- Search members using accented and unaccented forms such as `Ingeniería`, `ingenieria`, and `INGENIERÍA`.
- Filter members by equivalent career, skill, area, and project-label values.
- Search projects using different casing, accents, and repeated whitespace.
- Create equivalent skills or project labels and verify that duplicate normalized values are not stored or suggested.
- Verify that the original accented values remain unchanged when displayed.

## Screenshots / Evidence

Local verification:

- Frontend type-check: OK.
- Frontend lint for changed files: OK.
- Frontend tests: 52/52 passed.
- Frontend build: Not executed.
- Backend type-check/build: OK.
- Backend lint for changed files: OK.
- Backend build: OK.
- Focused backend tests: 81/81 passed.