### PR TITLE
fix(frontend): remove API leakage from member profiles

### DIFF
--- a/apps/backend/src/area-memberships/area-memberships.service.spec.ts
+++ b/apps/backend/src/area-memberships/area-memberships.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Area } from '../area/entities/area.entity';
@@ -154,11 +154,13 @@ describe('AreaMembershipsService', () => {
     areaMembershipsRepository.findOne.mockResolvedValue(membership);
     projectMembershipsRepository.findOne.mockResolvedValue({ id: 8 });
 
-    await expect(service.remove(membership.id)).rejects.toThrow(
-      new BadRequestException(
-        'Remove the member from active project teams in this area before changing or removing the area membership',
-      ),
-    );
+    await expect(service.remove(membership.id)).rejects.toMatchObject({
+      response: {
+        code: 'AREA_MEMBERSHIP_HAS_ACTIVE_PROJECTS',
+        message:
+          'Remove the member from active project teams in this area before changing or removing the area membership',
+      },
+    });
     expect(areaMembershipsRepository.remove).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/area-memberships/area-memberships.service.ts
+++ b/apps/backend/src/area-memberships/area-memberships.service.ts
@@ -148,9 +148,11 @@ export class AreaMembershipsService {
     });
 
     if (assignedProject) {
-      throw new BadRequestException(
-        'Remove the member from active project teams in this area before changing or removing the area membership',
-      );
+      throw new BadRequestException({
+        code: 'AREA_MEMBERSHIP_HAS_ACTIVE_PROJECTS',
+        message:
+          'Remove the member from active project teams in this area before changing or removing the area membership',
+      });
     }
   }
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src next.config.ts postcss.config.mjs",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/components/brand-logo.test.js .test-dist/app/components/tag-input.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/dashboard/dashboard-navigation.test.js .test-dist/app/member-profile-client.test.js .test-dist/app/phase-reordering.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/text-normalization.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/components/brand-logo.test.js .test-dist/app/components/tag-input.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/dashboard/dashboard-navigation.test.js .test-dist/app/member-profile-client.test.js .test-dist/app/people-management/shared.test.js .test-dist/app/phase-reordering.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/text-normalization.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src next.config.ts postcss.config.mjs",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/components/brand-logo.test.js .test-dist/app/components/tag-input.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/dashboard/dashboard-navigation.test.js .test-dist/app/phase-reordering.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/text-normalization.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/app/login/login-validation.test.js .test-dist/app/components/brand-logo.test.js .test-dist/app/components/tag-input.test.js .test-dist/app/dashboard/dashboard-route.test.js .test-dist/app/dashboard/dashboard-navigation.test.js .test-dist/app/member-profile-client.test.js .test-dist/app/phase-reordering.test.js .test-dist/app/project-experience.test.js .test-dist/app/people-management-utils.test.js .test-dist/app/tag-utils.test.js .test-dist/app/text-normalization.test.js .test-dist/app/task-collaboration.test.js .test-dist/app/task-management.test.js",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/frontend/src/app/dashboard/dashboard.components.tsx
+++ b/apps/frontend/src/app/dashboard/dashboard.components.tsx
@@ -3,7 +3,6 @@
 import Image from "next/image";
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { API_URL } from "@/lib/auth-client";
 import { BrandLogo } from "../components/brand-logo";
 import { BRAND_LOGO_WIDTHS } from "../components/brand-logo.config";
 import { fullName } from "./dashboard.model";
@@ -113,9 +112,9 @@ export function DashboardView({
 }) {
   return (
     <div>
-      <SectionTitle
+        <SectionTitle
         title="Dashboard"
-        subtitle="Resumen operativo de áreas, miembros y proyectos conectados al backend."
+        subtitle="Resumen operativo de áreas, miembros y proyectos de UNICORE."
       />
       <div className="grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1fr)_374px]">
         <div className="min-w-0 rounded-md border border-white/8 bg-[#20212c] p-5 sm:p-8">
@@ -178,14 +177,13 @@ export function DashboardView({
             empty="No hay proyectos para mostrar."
           />
         </Panel>
-        <Panel title="Estado de datos">
+        <Panel title="Tu acceso">
           <StackList
             items={[
-              { title: "Backend API", subtitle: API_URL, meta: "Conectado" },
               {
                 title: "Modo de acceso",
-                subtitle: authRole,
-                meta: "Bearer",
+                subtitle: authRole.replaceAll("_", " "),
+                meta: "Activo",
               },
             ]}
           />
@@ -196,12 +194,12 @@ export function DashboardView({
               {
                 title: "Listados dinámicos",
                 subtitle: "Áreas, miembros y proyectos",
-                meta: "API",
+                meta: "Actualizados",
               },
               {
-                title: "Charts",
-                subtitle: "Permitidos como mock en scope",
-                meta: "Mock",
+                title: "Resumen semanal",
+                subtitle: "Vista general de actividad",
+                meta: "Disponible",
               },
             ]}
           />
@@ -361,7 +359,6 @@ export function ProfileView({
               (member.areaId ? `Área ${member.areaId}` : "Todas")
             }
           />
-          <InfoRow label="API" value={API_URL.replace(/^https?:\/\//, "")} />
         </div>
         <button
           type="button"

--- a/apps/frontend/src/app/dashboard/dashboard.types.ts
+++ b/apps/frontend/src/app/dashboard/dashboard.types.ts
@@ -40,6 +40,8 @@ export type Member = {
   area?: Area | null;
   activityStatus?: "active" | "inactive" | string;
   availabilityStatus?: "available" | "not_available" | string;
+  createdAt?: string;
+  updatedAt?: string;
   disabledAt?: string | null;
   readOnly?: boolean;
   skills?: Skill[];

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -9,6 +9,10 @@ import {
   READ_ONLY_STORAGE_KEY,
   getJson,
 } from "@/lib/auth-client";
+import {
+  loadMemberProfile,
+  type MemberProfileLoadResult,
+} from "../member-profile-client";
 import ProjectManagement from "../project-management";
 import TaskManagement from "../task-management";
 import AuditManagementView from "../audit-management";
@@ -81,6 +85,10 @@ function DashboardContent() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [error, setError] = useState("");
+  const [memberProfileState, setMemberProfileState] = useState<
+    MemberProfileLoadResult | { status: "idle" | "loading" }
+  >({ status: "idle" });
+  const [memberProfileRefresh, setMemberProfileRefresh] = useState(0);
   const currentMemberRole = currentMember?.role;
   const visibleNavItems = navItems.filter((item) =>
     canSeeNavItem(item.id, currentMemberRole),
@@ -172,11 +180,7 @@ function DashboardContent() {
           return;
         }
 
-        setError(
-          currentError instanceof Error
-            ? currentError.message
-            : "No se pudo cargar la información",
-        );
+        setError("No pudimos cargar toda la información. Inténtalo nuevamente.");
         setLoadState("error");
       }
     }
@@ -187,6 +191,44 @@ function DashboardContent() {
       ignore = true;
     };
   }, [accessToken, authState, currentMemberRole]);
+
+  useEffect(() => {
+    if (
+      authState !== "authenticated" ||
+      !accessToken ||
+      !currentMemberRole ||
+      route.view !== "member-profile" ||
+      !route.resourceId
+    ) {
+      return;
+    }
+
+    const memberId = route.resourceId;
+    const token = accessToken;
+    const role = currentMemberRole;
+    let ignore = false;
+
+    async function loadProfile() {
+      await Promise.resolve();
+      if (ignore) return;
+      setMemberProfileState({ status: "loading" });
+      const result = await loadMemberProfile(memberId, token, role);
+      if (!ignore) setMemberProfileState(result);
+    }
+
+    void loadProfile();
+
+    return () => {
+      ignore = true;
+    };
+  }, [
+    accessToken,
+    authState,
+    currentMemberRole,
+    memberProfileRefresh,
+    route.resourceId,
+    route.view,
+  ]);
 
   useEffect(() => {
     if (loadState !== "ready" || view !== "areas" || !currentMemberRole) {
@@ -279,8 +321,9 @@ function DashboardContent() {
       : undefined;
 
   const selectedMember =
-    route.view === "member-profile"
-      ? members.find((member) => member.id === route.resourceId)
+    memberProfileState.status === "ready" &&
+    memberProfileState.member.id === route.resourceId
+      ? memberProfileState.member
       : undefined;
 
   const hasCreationAreaContext =
@@ -397,7 +440,7 @@ function DashboardContent() {
             )}
             {error && (
               <div className="mb-8 rounded-md border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
-                No se pudo conectar con la API en {API_URL}: {error}
+                {error}
               </div>
             )}
 
@@ -525,6 +568,15 @@ function DashboardContent() {
                   action="Volver"
                 />
               )}
+            {view === "member-profile" &&
+              routeAuthorized &&
+              (memberProfileState.status === "idle" ||
+                memberProfileState.status === "loading") && (
+                <RouteStateView
+                  title="Cargando perfil"
+                  description="Estamos preparando la información del miembro."
+                />
+              )}
             {view === "member-profile" && routeAuthorized && selectedMember && (
               <MemberProfileManagementView
                 member={selectedMember}
@@ -532,17 +584,21 @@ function DashboardContent() {
                 projects={projects}
                 accessToken={accessToken}
                 currentRole={currentMember.role}
-                onChanged={refreshPeopleData}
+                onChanged={async () => {
+                  await refreshPeopleData();
+                  setMemberProfileRefresh((value) => value + 1);
+                }}
                 onBack={() => router.push(getDashboardPath("members"))}
               />
             )}
             {view === "member-profile" &&
               routeAuthorized &&
-              loadState === "ready" &&
-              !selectedMember && (
+              (memberProfileState.status === "not-found" ||
+                memberProfileState.status === "unauthorized" ||
+                memberProfileState.status === "error") && (
                 <RouteStateView
-                  title="Miembro no encontrado"
-                  description="El perfil solicitado no existe o no está disponible para tu cuenta."
+                  title={memberProfileState.title}
+                  description={memberProfileState.description}
                   href={getDashboardPath("members")}
                   action="Volver a miembros"
                 />

--- a/apps/frontend/src/app/member-profile-client.test.ts
+++ b/apps/frontend/src/app/member-profile-client.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ApiError } from "../lib/auth-client";
+import {
+  MEMBER_PROFILE_MESSAGES,
+  loadMemberProfile,
+  normalizeMemberProfile,
+} from "./member-profile-client";
+
+const rawMember = {
+  id: 7,
+  firstNames: "Ada",
+  lastNames: "Lovelace",
+  institution: "UNI",
+  studentCode: "20260007",
+  major: "Ingeniería de Software",
+  birthDate: "2004-12-10",
+  cycle: 6,
+  role: "miembro",
+  activityStatus: "active",
+  availabilityStatus: "available",
+  createdAt: "2026-01-02T10:00:00.000Z",
+  updatedAt: "2026-08-03T10:00:00.000Z",
+  skills: [{ id: 2, name: " TypeScript " }, null, { name: "" }],
+  memberships: [
+    {
+      id: 4,
+      areaId: 3,
+      role: "miembro",
+      area: { id: 3, name: "Desarrollo", description: null },
+    },
+  ],
+};
+
+test("loads and normalizes a successful member profile", async () => {
+  const result = await loadMemberProfile(
+    7,
+    "secret-token",
+    "presidencia",
+    async <T>(path: string) => {
+      assert.equal(path, "/members");
+      return [rawMember] as T;
+    },
+  );
+
+  assert.equal(result.status, "ready");
+  if (result.status !== "ready") return;
+  assert.equal(result.member.firstNames, "Ada");
+  assert.deepEqual(result.member.skills, [{ id: 2, name: "TypeScript" }]);
+  assert.equal(result.member.memberships?.[0].area?.name, "Desarrollo");
+  assert.equal(result.member.activityStatus, "active");
+  assert.equal(result.member.createdAt, rawMember.createdAt);
+});
+
+test("returns a localized unauthorized state without making a request", async () => {
+  let requested = false;
+  const result = await loadMemberProfile(
+    7,
+    "secret-token",
+    "miembro",
+    async <T>() => {
+      requested = true;
+      return [] as T;
+    },
+  );
+
+  assert.equal(requested, false);
+  assert.deepEqual(result, {
+    status: "unauthorized",
+    ...MEMBER_PROFILE_MESSAGES.unauthorized,
+  });
+});
+
+test("returns a localized not-found state for an absent profile", async () => {
+  const result = await loadMemberProfile(
+    99,
+    "secret-token",
+    "directiva_de_area",
+    async <T>() => [rawMember] as T,
+  );
+
+  assert.deepEqual(result, {
+    status: "not-found",
+    ...MEMBER_PROFILE_MESSAGES.notFound,
+  });
+});
+
+test("hides technical API errors behind a localized state", async () => {
+  const technicalMessage =
+    "GET http://localhost:3001/members failed: invalid bearer token";
+  const result = await loadMemberProfile(
+    7,
+    "secret-token",
+    "presidencia",
+    async () => {
+      throw new ApiError(technicalMessage, 500);
+    },
+  );
+
+  assert.deepEqual(result, {
+    status: "error",
+    ...MEMBER_PROFILE_MESSAGES.error,
+  });
+  assert.equal(JSON.stringify(result).includes(technicalMessage), false);
+  assert.equal(JSON.stringify(result).includes("/members"), false);
+});
+
+test("maps forbidden API responses to the localized unauthorized state", async () => {
+  const result = await loadMemberProfile(
+    7,
+    "secret-token",
+    "presidencia",
+    async () => {
+      throw new ApiError("ForbiddenException: /members", 403);
+    },
+  );
+
+  assert.deepEqual(result, {
+    status: "unauthorized",
+    ...MEMBER_PROFILE_MESSAGES.unauthorized,
+  });
+});
+
+test("normalization strips internal fields for roles without visibility", () => {
+  const member = normalizeMemberProfile(rawMember, "miembro");
+
+  assert.ok(member);
+  assert.equal(member.institution, undefined);
+  assert.equal(member.studentCode, undefined);
+  assert.equal(member.birthDate, undefined);
+  assert.equal(member.activityStatus, undefined);
+  assert.equal(member.availabilityStatus, undefined);
+  assert.equal(member.skills?.[0].name, "TypeScript");
+});

--- a/apps/frontend/src/app/member-profile-client.ts
+++ b/apps/frontend/src/app/member-profile-client.ts
@@ -1,0 +1,178 @@
+import { ApiError, getJson } from "../lib/auth-client";
+import type { ManagedMember } from "./people-management.types";
+
+export const MEMBER_PROFILE_MESSAGES = {
+  unauthorized: {
+    title: "Acceso restringido",
+    description: "Tu rol no tiene permisos para consultar este perfil.",
+  },
+  notFound: {
+    title: "Miembro no encontrado",
+    description:
+      "El perfil solicitado no existe o no está disponible para tu cuenta.",
+  },
+  error: {
+    title: "No pudimos cargar el perfil",
+    description:
+      "Ocurrió un problema al consultar la información. Inténtalo nuevamente.",
+  },
+} as const;
+
+export type MemberProfileLoadResult =
+  | { status: "ready"; member: ManagedMember }
+  | { status: "unauthorized"; title: string; description: string }
+  | { status: "not-found"; title: string; description: string }
+  | { status: "error"; title: string; description: string };
+
+type MemberProfileRequest = <T>(
+  path: string,
+  accessToken: string,
+) => Promise<T>;
+
+export function canViewMemberProfiles(role?: string): boolean {
+  const normalizedRole = role?.trim().toLowerCase();
+  return normalizedRole === "presidencia" || normalizedRole === "directiva_de_area";
+}
+
+export function canViewInternalMemberProfileFields(role?: string): boolean {
+  return canViewMemberProfiles(role);
+}
+
+function stringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function optionalNullableString(value: unknown): string | null | undefined {
+  return value === null || typeof value === "string" ? value : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function normalizeMemberProfile(
+  payload: unknown,
+  viewerRole: string,
+): ManagedMember | null {
+  if (!payload || typeof payload !== "object") return null;
+
+  const value = payload as Record<string, unknown>;
+  const id = optionalNumber(value.id);
+  if (!id || !Number.isInteger(id)) return null;
+
+  const canViewInternal = canViewInternalMemberProfileFields(viewerRole);
+  const rawSkills = Array.isArray(value.skills) ? value.skills : [];
+  const rawMemberships = Array.isArray(value.memberships)
+    ? value.memberships
+    : [];
+
+  return {
+    id,
+    firstNames: stringValue(value.firstNames),
+    lastNames: stringValue(value.lastNames),
+    major: stringValue(value.major, "Sin carrera registrada"),
+    role: stringValue(value.role, "miembro"),
+    cycle: optionalNumber(value.cycle) ?? null,
+    areaId: optionalNumber(value.areaId) ?? null,
+    institution: canViewInternal ? optionalString(value.institution) : undefined,
+    studentCode: canViewInternal
+      ? optionalNullableString(value.studentCode)
+      : undefined,
+    birthDate: canViewInternal
+      ? optionalNullableString(value.birthDate)
+      : undefined,
+    activityStatus: canViewInternal
+      ? optionalString(value.activityStatus)
+      : undefined,
+    availabilityStatus: canViewInternal
+      ? optionalString(value.availabilityStatus)
+      : undefined,
+    createdAt: optionalString(value.createdAt),
+    updatedAt: optionalString(value.updatedAt),
+    skills: rawSkills.flatMap((skill) => {
+      if (!skill || typeof skill !== "object") return [];
+      const item = skill as Record<string, unknown>;
+      const name = stringValue(item.name).trim();
+      if (!name) return [];
+      return [{ id: optionalNumber(item.id), name }];
+    }),
+    memberships: rawMemberships.flatMap((membership) => {
+      if (!membership || typeof membership !== "object") return [];
+      const item = membership as Record<string, unknown>;
+      const rawArea =
+        item.area && typeof item.area === "object"
+          ? (item.area as Record<string, unknown>)
+          : undefined;
+      const areaId = optionalNumber(item.areaId) ?? null;
+      return [
+        {
+          id: optionalNumber(item.id),
+          areaId,
+          role: optionalString(item.role),
+          area:
+            rawArea && optionalNumber(rawArea.id)
+              ? {
+                  id: optionalNumber(rawArea.id)!,
+                  name: stringValue(rawArea.name, "Área sin nombre"),
+                  description: optionalNullableString(rawArea.description) ?? null,
+                  isArchived:
+                    typeof rawArea.isArchived === "boolean"
+                      ? rawArea.isArchived
+                      : undefined,
+                }
+              : undefined,
+        },
+      ];
+    }),
+  };
+}
+
+function state(
+  status: "unauthorized" | "not-found" | "error",
+): Exclude<MemberProfileLoadResult, { status: "ready" }> {
+  const message =
+    status === "not-found"
+      ? MEMBER_PROFILE_MESSAGES.notFound
+      : MEMBER_PROFILE_MESSAGES[status];
+  return { status, ...message };
+}
+
+export async function loadMemberProfile(
+  memberId: number,
+  accessToken: string,
+  viewerRole: string,
+  request: MemberProfileRequest = getJson,
+): Promise<MemberProfileLoadResult> {
+  if (!canViewMemberProfiles(viewerRole)) return state("unauthorized");
+
+  try {
+    const payload = await request<unknown>("/members", accessToken);
+    if (!Array.isArray(payload)) return state("error");
+
+    const member = payload
+      .map((item) => normalizeMemberProfile(item, viewerRole))
+      .find((item) => item?.id === memberId);
+
+    return member ? { status: "ready", member } : state("not-found");
+  } catch (error) {
+    if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+      return state("unauthorized");
+    }
+    return state("error");
+  }
+}
+
+export function formatProfileDate(value?: string): string {
+  if (!value) return "Sin registro";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Sin registro";
+  return new Intl.DateTimeFormat("es-PE", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+}

--- a/apps/frontend/src/app/people-management.types.ts
+++ b/apps/frontend/src/app/people-management.types.ts
@@ -28,6 +28,8 @@ export type ManagedMember = {
   area?: ManagedArea | null;
   activityStatus?: string;
   availabilityStatus?: string;
+  createdAt?: string;
+  updatedAt?: string;
   skills?: ManagedSkill[];
   memberships?: ManagedAreaMembership[];
 };

--- a/apps/frontend/src/app/people-management/profile.tsx
+++ b/apps/frontend/src/app/people-management/profile.tsx
@@ -4,6 +4,10 @@ import Image from "next/image";
 import { useState } from "react";
 import { authorizedJson } from "@/lib/auth-client";
 import type { ManagedArea, ManagedAreaMembership, ManagedMember, ManagedProject } from "../people-management.types";
+import {
+  canViewInternalMemberProfileFields,
+  formatProfileDate,
+} from "../member-profile-client";
 import { dangerButton, memberName, displayCycle, messageFrom, displayRole, StatusPill, Feedback } from "./shared";
 import { ExactNameAction } from "./areas";
 import { MemberForm } from "./member-form";
@@ -38,6 +42,7 @@ export function MemberProfileManagementView({
     project.memberships?.some((item) => item.memberId === member.id),
   );
   const canEdit = currentRole === "presidencia";
+  const canViewInternal = canViewInternalMemberProfileFields(currentRole);
   const canDeactivate =
     currentRole === "presidencia" || currentRole === "directiva_de_area";
   const removeMembership = async (item: ManagedAreaMembership) => {
@@ -88,19 +93,25 @@ export function MemberProfileManagementView({
           <p className="mt-1 text-center text-white/75">
             {member.major} · {displayCycle(member.cycle)}
           </p>
-          <div className="mt-4 flex justify-center gap-2">
-            <StatusPill value={member.activityStatus} />
-            <StatusPill value={member.availabilityStatus} />
-          </div>
+          {canViewInternal && (
+            <div className="mt-4 flex justify-center gap-2">
+              <StatusPill value={member.activityStatus} />
+              <StatusPill value={member.availabilityStatus} />
+            </div>
+          )}
           <div className="mt-6 space-y-3 border-t border-white/10 pt-5 text-sm">
-            <ProfileRow
-              label="Institución"
-              value={member.institution ?? "UNI"}
-            />
-            <ProfileRow
-              label="Código"
-              value={member.studentCode ?? "Sin código"}
-            />
+            {canViewInternal && (
+              <>
+                <ProfileRow
+                  label="Institución"
+                  value={member.institution ?? "Sin institución"}
+                />
+                <ProfileRow
+                  label="Código"
+                  value={member.studentCode ?? "Sin código"}
+                />
+              </>
+            )}
             <ProfileRow label="Rol" value={displayRole(member.role)} />
           </div>
           <div className="mt-6">
@@ -266,14 +277,16 @@ export function MemberProfileManagementView({
             </div>
           </section>
           <section className="rounded-md bg-[#191822] p-6 lg:p-8">
-            <h2 className="text-xl font-semibold">Participación</h2>
-            <div className="mt-6 rounded-md border border-dashed border-white/15 px-6 py-14 text-center">
-              <p className="text-sm font-medium text-white/65">
-                Aún no hay datos de participación disponibles.
-              </p>
-              <p className="mt-2 text-xs text-white/40">
-                Esta sección se completará cuando exista una fuente de métricas.
-              </p>
+            <h2 className="text-xl font-semibold">Historial del perfil</h2>
+            <div className="mt-6 grid gap-4 sm:grid-cols-2">
+              <HistoryItem
+                label="Registro"
+                value={formatProfileDate(member.createdAt)}
+              />
+              <HistoryItem
+                label="Última actualización"
+                value={formatProfileDate(member.updatedAt)}
+              />
             </div>
           </section>
         </div>
@@ -342,6 +355,15 @@ function ProfileRow({ label, value }: { label: string; value: string }) {
     <div className="flex justify-between gap-4">
       <span className="text-white/40">{label}</span>
       <span className="text-right font-semibold text-white/80">{value}</span>
+    </div>
+  );
+}
+
+function HistoryItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-white/10 bg-white/[0.03] px-5 py-4">
+      <p className="text-xs text-white/45">{label}</p>
+      <p className="mt-2 text-sm font-semibold text-white/80">{value}</p>
     </div>
   );
 }

--- a/apps/frontend/src/app/people-management/shared.test.ts
+++ b/apps/frontend/src/app/people-management/shared.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ApiError } from "../../lib/auth-client";
+import { messageFrom } from "./shared";
+
+test("explains how to remove an area membership used by active projects", () => {
+  const error = new ApiError(
+    "Remove the member from active project teams in this area",
+    400,
+    "AREA_MEMBERSHIP_HAS_ACTIVE_PROJECTS",
+  );
+
+  assert.equal(
+    messageFrom(error),
+    "Primero retira al miembro de los proyectos activos de esta área y luego vuelve a intentar cambiar o quitar su pertenencia.",
+  );
+  assert.equal(messageFrom(error).includes("Remove the member"), false);
+});

--- a/apps/frontend/src/app/people-management/shared.tsx
+++ b/apps/frontend/src/app/people-management/shared.tsx
@@ -36,7 +36,20 @@ export function displayCycle(cycle?: number | null): string {
 }
 
 export function messageFrom(error: unknown): string {
-  if (error instanceof ApiError || error instanceof Error) return error.message;
+  if (error instanceof ApiError) {
+    if (error.code === "DISABLED_READ_ONLY") {
+      return "Tu cuenta está inhabilitada y solo permite consultar información histórica.";
+    }
+    if (error.status === 401) return "Tu sesión venció. Vuelve a iniciar sesión.";
+    if (error.status === 403) return "Tu rol no permite realizar esta acción.";
+    if (error.status === 404) return "La información solicitada ya no está disponible.";
+    if (error.status === 409) return "La operación entra en conflicto con información existente.";
+    if (error.status >= 500) return "El servicio no está disponible. Inténtalo nuevamente.";
+    return "Revisa los datos ingresados e inténtalo nuevamente.";
+  }
+  if (error instanceof Error) {
+    return "No se pudo completar la operación. Inténtalo nuevamente.";
+  }
   return "No se pudo completar la operación.";
 }
 
@@ -199,4 +212,3 @@ export function SearchField({
     </label>
   );
 }
-

--- a/apps/frontend/src/app/people-management/shared.tsx
+++ b/apps/frontend/src/app/people-management/shared.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { ApiError } from "@/lib/auth-client";
+import { ApiError } from "../../lib/auth-client";
 import type { ManagedMember } from "../people-management.types";
 
 export const fieldClass =
@@ -39,6 +39,9 @@ export function messageFrom(error: unknown): string {
   if (error instanceof ApiError) {
     if (error.code === "DISABLED_READ_ONLY") {
       return "Tu cuenta está inhabilitada y solo permite consultar información histórica.";
+    }
+    if (error.code === "AREA_MEMBERSHIP_HAS_ACTIVE_PROJECTS") {
+      return "Primero retira al miembro de los proyectos activos de esta área y luego vuelve a intentar cambiar o quitar su pertenencia.";
     }
     if (error.status === 401) return "Tu sesión venció. Vuelve a iniciar sesión.";
     if (error.status === 403) return "Tu rol no permite realizar esta acción.";

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -17,6 +17,8 @@
     "src/app/project-experience.test.ts",
     "src/app/people-management-utils.ts",
     "src/app/people-management-utils.test.ts",
+    "src/app/member-profile-client.ts",
+    "src/app/member-profile-client.test.ts",
     "src/app/phase-reordering.ts",
     "src/app/phase-reordering.test.ts",
     "src/app/components/brand-logo.config.ts",

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -17,6 +17,8 @@
     "src/app/project-experience.test.ts",
     "src/app/people-management-utils.ts",
     "src/app/people-management-utils.test.ts",
+    "src/app/people-management/shared.tsx",
+    "src/app/people-management/shared.test.ts",
     "src/app/member-profile-client.ts",
     "src/app/member-profile-client.test.ts",
     "src/app/phase-reordering.ts",


### PR DESCRIPTION
## Summary

- move member profile loading and normalization into a dedicated client
- replace API paths, URLs, tokens, and technical errors with localized UI states
- enforce role-based visibility for internal member fields
- display activity, availability, area memberships, project roles, skills, and profile history consistently
- support direct navigation and profile refresh without relying on stale list data
- remove technical API information from dashboard-facing UI

## Testing

- `npm test`
- `npm run type-check`
- `npm run lint`
- `npm run build`

All 58 frontend tests pass.

Closes UNI2-41.